### PR TITLE
Fix bug in wit emulator

### DIFF
--- a/src/emulators/wit.py
+++ b/src/emulators/wit.py
@@ -16,7 +16,7 @@ class WitEmulator(object):
             "_text": data["text"],
             "confidence": None,
             "intent": data["intent"],
-            "entities" : {key:{"confidence":None,"type":"value","value":val} for key,val in data["entities"]}
+            "entities" : {key:{"confidence":None,"type":"value","value":val} for key,val in data["entities"].items()}
           }
         ]
 


### PR DESCRIPTION
Error message I got:
```
127.0.0.1 - - [08/Nov/2016 17:24:07] "GET /parse?q=I+need+a+table+for+4pm HTTP/1.1" 200 -
plain response {'text': 'I need a table for 4pm', 'intent': 'inform', 'entities': {'cuisine': 'table'}}
----------------------------------------
Exception happened during processing of request from ('127.0.0.1', 52584)
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.12_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 290, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/local/Cellar/python/2.7.12_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 318, in process_request
    self.finish_request(request, client_address)
  File "/usr/local/Cellar/python/2.7.12_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 331, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/local/Cellar/python/2.7.12_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 652, in __init__
    self.handle()
  File "/usr/local/Cellar/python/2.7.12_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/BaseHTTPServer.py", line 340, in handle
    self.handle_one_request()
  File "/usr/local/Cellar/python/2.7.12_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/BaseHTTPServer.py", line 328, in handle_one_request
    method()
  File "build/bdist.macosx-10.12-x86_64/egg/parsa/server.py", line 89, in do_GET
  File "build/bdist.macosx-10.12-x86_64/egg/parsa/server.py", line 81, in get_response
  File "build/bdist.macosx-10.12-x86_64/egg/parsa/server.py", line 64, in format
  File "build/bdist.macosx-10.12-x86_64/egg/parsa/emulators/wit.py", line 19, in normalise_response_json
    "entities" : {key:{"confidence":None,"type":"value","value":val} for key,val in data["entities"]}
  File "build/bdist.macosx-10.12-x86_64/egg/parsa/emulators/wit.py", line 19, in <dictcomp>
    "entities" : {key:{"confidence":None,"type":"value","value":val} for key,val in data["entities"]}
ValueError: too many values to unpack
```