### PR TITLE
Escaping the tokens to be matched

### DIFF
--- a/_pytest/test_training_data.py
+++ b/_pytest/test_training_data.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 from rasa_nlu.training_data import TrainingData
 
 
@@ -20,3 +21,35 @@ def test_rasa_whitespace():
 def test_api_mitie():
     td = TrainingData('data/examples/api/', 'mitie', 'en')
     assert td.fformat == 'api'
+
+def test_nonascii_entities():
+    data = u"""
+{
+  "luis_schema_version": "1.0",
+  "utterances" : [
+    {
+      "text": "I am looking for a ßäæ ?€ö) item",
+      "intent": "unk",
+      "entities": [
+        {
+          "entity": "description",
+          "startPos": 5,
+          "endPos": 8
+        }
+      ]
+    }
+  ]
+}"""
+    filename = 'tmp_training_data.json'
+    with open(filename, 'w') as f:
+        f.write(data.encode("utf-8"))
+    td = TrainingData(filename, 'mitie', 'en')
+    assert len(td.entity_examples) == 1
+    example = td.entity_examples[0]
+    entities = example["entities"]
+    assert len(entities) == 1
+    entity = entities[0]
+    assert entity["value"] == u"ßäæ ?€ö)"
+    assert entity["start"] == 19
+    assert entity["end"] == 27
+    assert entity["entity"] == "description"

--- a/_pytest/test_training_data.py
+++ b/_pytest/test_training_data.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 from rasa_nlu.training_data import TrainingData
 
 
@@ -20,6 +21,7 @@ def test_rasa_whitespace():
 def test_api_mitie():
     td = TrainingData('data/examples/api/', 'mitie', 'en')
     assert td.fformat == 'api'
+
 
 def test_nonascii_entities():
     data = u"""

--- a/src/training_data.py
+++ b/src/training_data.py
@@ -92,7 +92,7 @@ class TrainingData(object):
             entities = []
             for e in s.get("entities") or []:
                 i, ii = e["startPos"], e["endPos"] + 1
-                _regex = u"\s*".join([s for s in tokens[i:ii]])
+                _regex = u"\s*".join([re.escape(s.decode("utf-8")) for s in tokens[i:ii]])
                 expr = re.compile(_regex)
                 m = expr.search(text)
                 start, end = m.start(), m.end()


### PR DESCRIPTION
Escaping the tokens to be matched If they include non-alpha chars like ? or (, the regex might not match them. Decoding the tokens to support non-ascii chars.