### PR TITLE
visualise entities in training data

### DIFF
--- a/docs/closeloop.rst
+++ b/docs/closeloop.rst
@@ -1,3 +1,4 @@
+.. _section_closeloop:
 
 Closing the loop: improving your models from feedback
 ====================================
@@ -7,3 +8,4 @@ Closing the loop: improving your models from feedback
 When the rasa_nlu server is running, it keeps track of all the predictions it's made and saves these to a log file. 
 By default this is called ``rasa_nlu_log.json``
 You can fix any incorrect predictions and add them to your training set to improve your parser.
+After adding these to your training data, but before retraining your model, it is strongly recommended that you use the visualizer to spot any errors, see :ref:`section_visualization`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -21,7 +21,7 @@ Here is a list of all rasa NLU configuration options:
 - ``data`` : file containing training data.
 - ``emulate`` :  service to emulate. can be ``wit``, ``luis``, or ``api``.
 - ``language`` : language of your app, can be ``en`` (English) or ``de`` (German).
-- ``mitie_file`` : file containing ``total_word_feature_extractor.dat`` (see :ref:`backends`)
+- ``mitie_file`` : file containing ``total_word_feature_extractor.dat`` (see :ref:`section_backends`)
 - ``path`` : where trained models will be saved.
 - ``port`` : port on which to run server.
 - ``server_model_dir`` : dir containing the model to be used by server.

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -3,7 +3,7 @@ Contributing
 ==================================
 
 contributions are very much encouraged! 
-Please create an issue before doing any work to avoid disaapointment
+Please create an issue before doing any work to avoid disappointment
 
 
 Python Conventions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,7 +46,7 @@ The quickest quickstart in the west
     [{"_text":"hello","confidence":null,"entities":{},"intent":"greet"}]
 
 
-There you go! you just parsed some text. Next step, do the :ref:`tutorial`.
+There you go! you just parsed some text. Next step, do the :ref:`section_tutorial`.
 
 About 
 ---------------------------------------
@@ -73,6 +73,7 @@ Read Next:
    config
    migrating
    http
+   visualize
    closeloop
    persist
    troubleshoot

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -30,6 +30,7 @@ When you download your model, the entity locations are specified by the index of
 This is pretty fragile because not every tokenizer will behave the same as LUIS's, so your entities may be incorrectly labelled. 
 Run your training once and you'll get a copy of your training data in the ``model_XXXXX`` dir. 
 Do any fixes required and use that to train. 
+Use the visualizer (see :ref:`section_visualization`) to spot mistakes easily.
 
 api.ai
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -33,7 +33,7 @@ The first job of rasa NLU is to assign any given sentence to one of the categori
 The second job is to label words like "Mexican" and "center" as ``cuisine`` and ``location`` entities, respectively. 
 In this tutorial we'll build a model which does exactly that.
 
-Training Data
+Preparing the Training Data
 ------------------------------------
 
 The best way to get training data is from *real users*, and the best way to do that is to `pretend to be the bot yourself <https://conversations.golastmile.com/put-on-your-robot-costume-and-be-the-minimum-viable-bot-yourself-3e48a5a59308#.d4tmdan68>`_. But to help get you started we have some data saved `here <https://github.com/golastmile/rasa_nlu/blob/master/data/demo-rasa.json>`_
@@ -67,6 +67,18 @@ Download the file and open it, and you'll see a list of training examples like t
 hopefully the format is intuitive if you've read this far into the tutorial.
 In your working directory, create a ``data`` folder, and copy the ``demo-rasa.json`` file there.
 
+It's always a good idea to `look` at your data before, during, and after training a model. 
+To make this a bit simpler rasa NLU has a ``visualise`` tool, see :ref:`section_visualization`.
+For the demo data the output should look like this:
+
+.. image:: https://cloud.githubusercontent.com/assets/5114084/20884979/452df93c-bae6-11e6-8a2b-a6ad52306ae0.png
+
+
+It is **strongly** recommended that you use the visualizer to do a sanity check before training.
+
+
+Training Your Model
+------------------------------------
 
 Now we're going to create a configuration file. Make sure first that you've set up a backend, see :ref:`section_backends` .
 Create a file called ``config.json`` in your working directory which looks like this

--- a/docs/visualize.rst
+++ b/docs/visualize.rst
@@ -1,0 +1,18 @@
+.. _section_visualization:
+
+Visualization
+==================================
+
+
+rasa NLU has a very simple visualizer to help you spot mistakes in your training data. 
+To use it, run 
+
+.. code-block:: bash
+
+    $ python -m rasa_nlu visualize path/to/data.json
+
+
+and visit http://0.0.0.0:8080/ in your web browser. 
+
+This is also helpful for spotting errors in your output, before retraining, see :ref:`section_closeloop`.
+

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(
         'rasa_nlu.featurizers',
         'rasa_nlu.interpreters',
         'rasa_nlu.trainers',
-        'rasa_nlu.tokenizers'
+        'rasa_nlu.tokenizers',
+        'rasa_nlu.visualization'
     ],
     package_dir={'rasa_nlu': 'src'},
     version='0.4.1.1',

--- a/src/visualization/__init__.py
+++ b/src/visualization/__init__.py
@@ -1,0 +1,88 @@
+from itertools import cycle
+
+
+def entity_spec(name, red, green, blue):
+    return """
+[data-entity][data-entity="{name}"] {{
+    background: rgba({r}, {g}, {b}, 0.2);
+    border-color: rgb({r}, {g}, {b});
+}}
+
+[data-entity][data-entity="{name}"]::after {{
+    background: rgb({r}, {g}, {b});
+}}""".format(name=name, r=red, g=green, b=blue)
+
+
+def create_css(entity_examples):
+    colors = cycle([(166, 226, 45), (67, 198, 252), (47, 187, 171)])
+    entity_types = set()
+    for example in entity_examples:
+        for entity in example["entities"]:
+            entity_types.add(entity["entity"])
+    entity_specs = u"\n".join([entity_spec(name, *next(colors)) for name in entity_types])
+    return u"""
+    <style media="screen" type="text/css">
+    .entities {{
+        line-height: 2;
+    }}
+    [data-entity] {{
+        padding: 0.25em 0.35em;
+         margin: 0px 0.25em;
+         line-height: 1;
+         display: inline-block;
+         border-radius: 0.25em;
+         border: 1px solid;
+    }}
+
+    [data-entity]::after {{
+        box-sizing: border-box;
+        content: attr(data-entity);
+        font-size: 0.6em;
+        line-height: 1;
+        padding: 0.35em;
+        border-radius: 0.35em;
+        text-transform: uppercase;
+        display: inline-block;
+        vertical-align: middle;
+        margin: 0px 0px 0.1rem 0.5rem;
+    }}
+    {entity_specs}
+    </style>""".format(entity_specs=entity_specs)
+
+
+def html_wrapper():
+    return u"""
+<!DOCTYPE html>
+<html>
+  <head>
+    {head}
+  </head>
+  <body>
+    {body}
+  </body>
+</html>
+    """
+
+
+def format_example(example):
+    text = example["text"]
+    entities = sorted(example["entities"], key=lambda e: e['start'])
+    chunks = []
+    end = 0
+    while len(entities) > 0:
+        entity = entities.pop(0)
+        start = entity["start"]
+        chunks.append(text[end:start])
+        end = entity["end"]
+        markup = u"""<mark data-entity="{0}">{1}</mark>""".format(entity["entity"], text[start:end])
+        chunks.append(markup)
+    chunks.append(text[end:])
+    return u"<div>{0}</div>".format(u"".join(chunks))
+
+
+def create_html(training_data):
+    examples = [e for e in training_data.entity_examples if len(e["entities"]) > 0]
+    body = u"".join([format_example(example) for example in examples])
+    head = create_css(examples)
+    template = html_wrapper()
+    return template.format(head=head, body=body)

--- a/src/visualize.py
+++ b/src/visualize.py
@@ -1,0 +1,48 @@
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from rasa_nlu.visualization import create_html
+from rasa_nlu.training_data import TrainingData
+import sys
+
+
+class NLUVisualizationServer(object):
+    def __init__(self, config):
+        self.server = None
+        self.config = config
+
+    def start(self):
+        self.server = HTTPServer(('', 8080), lambda *args: VisualizationRequestHandler(*args))
+        print('Started http server at http://0.0.0.0:8080')
+        self.server.serve_forever()
+
+    def stop(self):
+        print '^C received. Aborting.'
+        if self.server is not None:
+            print 'shutting down server'
+            self.server.socket.close()
+
+
+class VisualizationRequestHandler(BaseHTTPRequestHandler):
+    def __init__(self, *args):
+        BaseHTTPRequestHandler.__init__(self, *args)
+
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_GET(self):
+        self._set_headers()
+        data_file = sys.argv[1]
+        training_data = TrainingData(data_file, 'mitie', 'en')
+        data = create_html(training_data)
+        self.wfile.write(data)
+        return
+
+
+if __name__ == "__main__":
+
+    try:
+        server = NLUVisualizationServer(None)
+        server.start()
+    except KeyboardInterrupt:
+        server.stop()


### PR DESCRIPTION
Thought it would be useful for debugging to have some basic support for visualising entities in training data. 

To use it you run e.g. 

```bash
python -mrasa_nlu.visualize data/examples/luis/demo-restaurants.json 
```

if you then point your browser to http://0.0.0.0:8080/ , you should see something like this:

![image](https://cloud.githubusercontent.com/assets/5114084/20884979/452df93c-bae6-11e6-8a2b-a6ad52306ae0.png)


implementation is pretty quick and dirty so **suggestions for improvement are welcome!** 