### PR TITLE
Unicode server

### DIFF
--- a/_pytest/test_emulators.py
+++ b/_pytest/test_emulators.py
@@ -8,7 +8,7 @@ def test_luis_request():
 def test_luis_response():
     from rasa_nlu.emulators.luis import LUISEmulator
     em = LUISEmulator()
-    data = {"text": "I want italian food", "intent": "inform", "entities": {"cuisine": "italian"}}
+    data = {"text": "I want italian food", "intent": "inform", "entities": [{"entity": "cuisine", "value": "italian"}]}
     norm = em.normalise_response_json(data)
     assert norm == {
         "query": data["text"],
@@ -18,8 +18,8 @@ def test_luis_response():
         },
         "entities": [
             {
-                "entity": e[0],
-                "type": e[1],
+                "entity": e["value"],
+                "type": e["entity"],
                 "startIndex": None,
                 "endIndex": None,
                 "score": None
@@ -38,7 +38,7 @@ def test_wit_request():
 def test_wit_response():
     from rasa_nlu.emulators.wit import WitEmulator
     em = WitEmulator()
-    data = {"text": "I want italian food", "intent": "inform", "entities": {"cuisine": "italian"}}
+    data = {"text": "I want italian food", "intent": "inform", "entities": [{"entity": "cuisine", "value": "italian"}]}
     norm = em.normalise_response_json(data)
     assert norm == [
         {'entities': {'cuisine': {'confidence': None, 'type': 'value', 'value': 'italian'}}, 'confidence': None,

--- a/_pytest/test_emulators.py
+++ b/_pytest/test_emulators.py
@@ -38,11 +38,14 @@ def test_wit_request():
 def test_wit_response():
     from rasa_nlu.emulators.wit import WitEmulator
     em = WitEmulator()
-    data = {"text": "I want italian food", "intent": "inform", "entities": [{"entity": "cuisine", "value": "italian"}]}
+    data = {
+        "text": "I want italian food",
+        "intent": "inform",
+        "entities": [{"entity": "cuisine", "value": "italian", "start": 7, "end": 14}]}
     norm = em.normalise_response_json(data)
     assert norm == [
-        {'entities': {'cuisine': {'confidence': None, 'type': 'value', 'value': 'italian'}}, 'confidence': None,
-         'intent': 'inform', '_text': 'I want italian food'}]
+        {'entities': {'cuisine': {'confidence': None, 'type': 'value', 'value': 'italian', 'start': 7, 'end': 14}},
+         'confidence': None, 'intent': 'inform', '_text': 'I want italian food'}]
 
 
 def test_dummy_request():

--- a/_pytest/test_server.py
+++ b/_pytest/test_server.py
@@ -59,11 +59,11 @@ def test_status(http_server):
 def test_get_parse(http_server):
     tests = [
         ResponseTest(
-            "/parse?q=hello",
+            u"/parse?q=hello",
             [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello"}]
         ),
         ResponseTest(
-            "/parse?q=hello ńöñàśçií",
+            u"/parse?q=hello ńöñàśçií",
             [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello ńöñàśçií"}]
         ),
     ]
@@ -75,14 +75,14 @@ def test_get_parse(http_server):
 def test_post_parse(http_server):
     tests = [
         ResponseTest(
-            "/parse",
+            u"/parse",
             [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello"}],
-            payload={"q": "hello"}
+            payload={u"q": u"hello"}
         ),
         ResponseTest(
-            "/parse",
+            u"/parse",
             [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello ńöñàśçií"}],
-            payload={"q": "hello ńöñàśçií"}
+            payload={u"q": u"hello ńöñàśçií"}
         ),
     ]
     for test in tests:

--- a/_pytest/test_server.py
+++ b/_pytest/test_server.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 import requests
 import os
@@ -49,13 +51,13 @@ def test_status(http_server):
 
 def test_get_parse(http_server):
     req = requests.get(http_server + "/parse?q=hello")
-    expected = [{"entities": {}, "confidence": None, "intent": "greet", "_text": "hello"}]
+    expected = [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello"}]
     assert req.status_code == 200 and req.json() == expected
 
 
 def test_post_parse(http_server):
     req = requests.post(http_server + "/parse", json={"q": "hello"})
-    expected = [{"entities": {}, "confidence": None, "intent": "greet", "_text": "hello"}]
+    expected = [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello"}]
     assert req.status_code == 200 and req.json() == expected
 
 

--- a/_pytest/test_server.py
+++ b/_pytest/test_server.py
@@ -11,6 +11,13 @@ import json
 import codecs
 
 
+class ResponseTest():
+    def __init__(self, endpoint, expected_response, payload=None):
+        self.endpoint = endpoint
+        self.expected_response = expected_response
+        self.payload = payload
+
+
 @pytest.fixture
 def http_server():
     def url(port):
@@ -50,22 +57,41 @@ def test_status(http_server):
 
 
 def test_get_parse(http_server):
-    req = requests.get(http_server + "/parse?q=hello")
-    expected = [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello"}]
-    assert req.status_code == 200 and req.json() == expected
+    tests = [
+        ResponseTest(
+            "/parse?q=hello",
+            [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello"}]
+        ),
+        ResponseTest(
+            "/parse?q=hello ńöñàśçií",
+            [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello ńöñàśçií"}]
+        ),
+    ]
+    for test in tests:
+        req = requests.get(http_server + test.endpoint)
+        assert req.status_code == 200 and req.json() == test.expected_response
 
 
 def test_post_parse(http_server):
-    req = requests.post(http_server + "/parse", json={"q": "hello"})
-    expected = [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello"}]
-    assert req.status_code == 200 and req.json() == expected
+    tests = [
+        ResponseTest(
+            "/parse",
+            [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello"}],
+            payload={"q": "hello"}
+        ),
+        ResponseTest(
+            "/parse",
+            [{u"entities": {}, u"confidence": None, u"intent": u"greet", u"_text": u"hello ńöñàśçií"}],
+            payload={"q": "hello ńöñàśçií"}
+        ),
+    ]
+    for test in tests:
+        req = requests.post(http_server + test.endpoint, json=test.payload)
+        assert req.status_code == 200 and req.json() == test.expected_response
 
 
 def test_post_train(http_server):
     train_data = json.loads(codecs.open('data/examples/luis/demo-restaurants.json',
                                         encoding='utf-8').read())
     req = requests.post(http_server + "/parse", json=train_data)
-    # TODO: POST /train oddly returns an error msg but training works fine
-    # For now check only status code. Later on take a look at actual response
-    # assert req.status_code == 200 and "training started with pid" in req.text
     assert req.status_code == 200

--- a/_pytest/test_tokenizers.py
+++ b/_pytest/test_tokenizers.py
@@ -6,8 +6,8 @@ import pytest
 def test_whitespace():
     from rasa_nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
     tk = WhitespaceTokenizer()
-    sentence = u"Hi. My name is rasa"
-    assert tk.tokenize(sentence) == [u'Hi.', u'My', u'name', u'is', u'rasa']
+    assert tk.tokenize(u"Hi. My name is rasa") == [u'Hi.', u'My', u'name', u'is', u'rasa']
+    assert tk.tokenize(u"hello ńöñàśçií") == [u'hello', u'ńöñàśçií']
 
 
 def test_spacy():

--- a/_pytest/test_tokenizers.py
+++ b/_pytest/test_tokenizers.py
@@ -17,6 +17,7 @@ def test_spacy():
         assert tk.tokenize(sentence) == expected_result
 
     tokenize_sentence(u"Hi. My name is rasa", [u'Hi', u'.', u'My', u'name', u'is', u'rasa'], 'en')
+    tokenize_sentence(u"hello ńöñàśçií", [u'hello', u'ńöñàśçií'], 'en')
     tokenize_sentence(u"Hallo. Mein name ist rasa", [u'Hallo', u'.', u'Mein', u'name', u'ist', u'rasa'], 'de')
 
 

--- a/src/emulators/api.py
+++ b/src/emulators/api.py
@@ -13,6 +13,11 @@ class ApiEmulator(object):
         return _data
 
     def normalise_response_json(self, data):
+        # populate entities dict
+        entities = {entity_type: [] for entity_type in set(map(lambda x: x["entity"], data["entities"]))}
+        for entity in data["entities"]:
+            entities[entity["entity"]].append(entity["value"])
+
         return {
             "id": unicode(uuid.uuid1()),
             "timestamp": datetime.now().isoformat("T"),
@@ -21,7 +26,7 @@ class ApiEmulator(object):
                 "resolvedQuery": data["text"],
                 "action": None,
                 "actionIncomplete": None,
-                "parameters": {key: val for key, val in data["entities"].items()},
+                "parameters": entities,
                 "contexts": [],
                 "metadata": {
                     "intentId": unicode(uuid.uuid1()),

--- a/src/emulators/luis.py
+++ b/src/emulators/luis.py
@@ -16,8 +16,8 @@ class LUISEmulator(object):
             },
             "entities": [
                 {
-                    "entity": e[0],
-                    "type": e[1],
+                    "entity": e["value"],
+                    "type": e["entity"],
                     "startIndex": None,
                     "endIndex": None,
                     "score": None

--- a/src/emulators/wit.py
+++ b/src/emulators/wit.py
@@ -4,17 +4,21 @@ class WitEmulator(object):
 
     def normalise_request_json(self, data):
         _data = {}
+        print data
         _data["text"] = data["q"][0] if type(data["q"]) == list else data["q"]
         return _data
 
     def normalise_response_json(self, data):
         print('plain response {0}'.format(data))
+        entities = {}
+        for entity in data["entities"]:
+            entities[entity["entity"]] = {"confidence": None, "type": "value", "value": entity["value"]}
+
         return [
             {
                 "_text": data["text"],
                 "confidence": None,
                 "intent": data["intent"],
-                "entities": {key: {"confidence": None, "type": "value", "value": val} for key, val in
-                             data["entities"].items()}
+                "entities": entities
             }
         ]

--- a/src/emulators/wit.py
+++ b/src/emulators/wit.py
@@ -4,7 +4,6 @@ class WitEmulator(object):
 
     def normalise_request_json(self, data):
         _data = {}
-        print data
         _data["text"] = data["q"][0] if type(data["q"]) == list else data["q"]
         return _data
 
@@ -12,7 +11,13 @@ class WitEmulator(object):
         print('plain response {0}'.format(data))
         entities = {}
         for entity in data["entities"]:
-            entities[entity["entity"]] = {"confidence": None, "type": "value", "value": entity["value"]}
+            entities[entity["entity"]] = {
+                "confidence": None,
+                "type": "value",
+                "value": entity["value"],
+                "start": entity["start"],
+                "end": entity["end"]
+            }
 
         return [
             {

--- a/src/interpreters/mitie_interpreter.py
+++ b/src/interpreters/mitie_interpreter.py
@@ -1,5 +1,6 @@
 from mitie import *
 from rasa_nlu import Interpreter
+from rasa_nlu.tokenizers.mitie_tokenizer import MITIETokenizer
 import re
 
 
@@ -7,9 +8,10 @@ class MITIEInterpreter(Interpreter):
     def __init__(self, intent_classifier=None, entity_extractor=None, feature_extractor=None, **kwargs):
         self.extractor = named_entity_extractor(entity_extractor, feature_extractor)
         self.classifier = text_categorizer(intent_classifier, feature_extractor)
+        self.tokenizer = MITIETokenizer()
 
     def get_entities(self, text):
-        tokens = tokenize(text)
+        tokens = self.tokenizer.tokenize(text)
         ents = []
         entities = self.extractor.extract_entities(tokens)
         for e in entities:

--- a/src/interpreters/mitie_sklearn_interpreter.py
+++ b/src/interpreters/mitie_sklearn_interpreter.py
@@ -1,11 +1,13 @@
-from mitie import tokenize
+from mitie import named_entity_extractor, text_categorizer
 from rasa_nlu import Interpreter
+from rasa_nlu.tokenizers.mitie_tokenizer import MITIETokenizer
 
 
 class MITIESklearnInterpreter(Interpreter):
     def __init__(self, metadata):
         self.extractor = named_entity_extractor(metadata["entity_extractor"])  # ,metadata["feature_extractor"])
         self.classifier = text_categorizer(metadata["intent_classifier"])  # ,metadata["feature_extractor"])
+        self.tokenizer = MITIETokenizer()
 
     def get_entities(self, tokens):
         d = {}
@@ -20,7 +22,7 @@ class MITIESklearnInterpreter(Interpreter):
         return label
 
     def parse(self, text):
-        tokens = tokenize(text)
+        tokens = self.tokenizer.tokenize(text)
         intent = self.get_intent(tokens)
         entities = self.get_entities(tokens)
 

--- a/src/server.py
+++ b/src/server.py
@@ -201,7 +201,9 @@ class RasaRequestHandler(BaseHTTPRequestHandler):
                 self._set_headers()
                 data_string = self.rfile.read(int(self.headers['Content-Length']))
                 self.data_router.start_train_proc(data_string)
-                self.wfile.write('training started with pid {0}'.format(self.data_router.train_proc.pid))
+                self.wfile.write(
+                    json.dumps({"info": "training started with pid {0}".format(self.data_router.train_proc.pid)})
+                )
         else:
             self.auth_err()
         return

--- a/src/server.py
+++ b/src/server.py
@@ -168,6 +168,9 @@ class RasaRequestHandler(BaseHTTPRequestHandler):
         self.wfile.write("unauthorized")
 
     def get_response(self, data_dict):
+        if u'q' not in data_dict:
+            return json.dumps({"error": "Invalid parse parameter specified"})
+
         data = self.data_router.extract(data_dict)
         result = self.data_router.parse(data["text"])
         response = self.data_router.format(result)
@@ -177,7 +180,7 @@ class RasaRequestHandler(BaseHTTPRequestHandler):
         if self.data_router.auth(self.path):
             self._set_headers()
             if self.path.startswith("/parse"):
-                parsed_path = urlparse.urlparse(self.path)
+                parsed_path = urlparse.urlparse(urlparse.unquote(self.path).decode('utf-8'))
                 data = urlparse.parse_qs(parsed_path.query)
                 self.wfile.write(self.get_response(data))
             elif self.path.startswith("/status"):
@@ -194,13 +197,14 @@ class RasaRequestHandler(BaseHTTPRequestHandler):
             if self.path.startswith("/parse"):
                 self._set_headers()
                 data_string = self.rfile.read(int(self.headers['Content-Length']))
-                data_dict = json.loads(data_string)
+                data_dict = json.loads(data_string.decode("utf-8"))
                 self.wfile.write(self.get_response(data_dict))
 
             if self.path.startswith("/train"):
                 self._set_headers()
                 data_string = self.rfile.read(int(self.headers['Content-Length']))
                 self.data_router.start_train_proc(data_string)
+                self.data_router.start_train_proc(data_string.decode("utf-8"))
                 self.wfile.write(
                     json.dumps({"info": "training started with pid {0}".format(self.data_router.train_proc.pid)})
                 )

--- a/src/tokenizers/mitie_tokenizer.py
+++ b/src/tokenizers/mitie_tokenizer.py
@@ -6,4 +6,4 @@ class MITIETokenizer(object):
         pass
 
     def tokenize(self, text):
-        return tokenize(text)
+        return [w.decode('utf-8') for w in tokenize(text.encode('utf-8'))]

--- a/src/training_data.py
+++ b/src/training_data.py
@@ -92,7 +92,7 @@ class TrainingData(object):
             entities = []
             for e in s.get("entities") or []:
                 i, ii = e["startPos"], e["endPos"] + 1
-                _regex = u"\s*".join([re.escape(s.decode("utf-8")) for s in tokens[i:ii]])
+                _regex = u"\s*".join([re.escape(s) for s in tokens[i:ii]])
                 expr = re.compile(_regex)
                 m = expr.search(text)
                 start, end = m.start(), m.end()


### PR DESCRIPTION
addresses issue #44 

@plauto I would still have a test which includes the server, e.g. 

`requests.post(http_server + "/parse", json={"q": u"hello ńöñàśçií"})` in `test_post_parse()`

and you're right that entities should be a **list**, but with the start and end of each entity specified, e.g. 
```json
      {
        "text": "show me chinese restaurants",
        "intent": "restaurant_search",
        "entities": [
          {
            "start": 8,
            "end": 15,
            "value": "chinese",
            "entity": "cuisine"
          }
        ]
      }```