### PR TITLE
docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:2
+
+ADD . /rasa_nlu
+
+WORKDIR /rasa_nlu
+
+RUN pip install -r requirements.txt && \
+    python setup.py install && \
+    python -m spacy.en.download all > /dev/null && \
+    python -m spacy.de.download all > /dev/null && \
+    cp entrypoint.sh /sbin/entrypoint.sh && \
+    chmod 777 entrypoint.sh
+
+ENV RASA_NLU_DOCKER="YES"
+
+EXPOSE 5000
+
+ENTRYPOINT ["/sbin/entrypoint.sh"]
+CMD ["help"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+case ${1} in
+    start)
+        python -m rasa_nlu.server "${@:2}" 
+        ;;
+    run)
+        "${@:2}"
+        ;;
+    *)
+        echo "Available options:"
+        echo " start <rasa_nlu_arguments>  - Start RasaNLU server"
+        echo " start -h                    - Print RasaNLU help"
+        echo " help                        - Print this help" 
+        echo " run                         - Run an arbitrary command inside the container"
+        ;;
+esac
+

--- a/src/server.py
+++ b/src/server.py
@@ -19,7 +19,7 @@ class RasaNLUServer(object):
         self.interpreter = self.__create_interpreter()
         self.data_router = DataRouter(config, self.interpreter, self.emulator)
 
-        if 'DYNO' in os.environ and config.backend == 'mitie':  # running on Heroku
+        if ('DYNO' in os.environ or 'RASA_NLU_DOCKER' in os.environ) and config.backend == 'mitie':  # running on Heroku
             from rasa_nlu.featurizers.mitie_featurizer import MITIEFeaturizer
             MITIEFeaturizer(config.mitie_file)
 


### PR DESCRIPTION
This allows to dockerize rasa_nlu. To run, clone the project and run the following commands:
```
docker build -t rasa_nlu:1.0 .
docker run -p 5000:5000 --rm --name rasa_test -it rasa_nlu:1.0 -e wit
```
might take some time to download everything (especially spacy, which gives some troubles today during the download process). Moreover, if run with mitie the first run will require the download of total_words.dat from S3.
After that you might want to run it with the option -d instead of --rm (thus, in detatched mode)
```
docker run -p 5000:5000 -d --name rasa_test -it rasa_nlu:1.0 -e wit
```

To test connect to localhost:5000