### PR TITLE
fixed two issues with german spacy

### DIFF
--- a/src/trainers/spacy_sklearn_trainer.py
+++ b/src/trainers/spacy_sklearn_trainer.py
@@ -19,7 +19,7 @@ class SpacySklearnTrainer(Trainer):
         self.name = "spacy_sklearn"
         self.language_name = language_name
         self.training_data = None
-        self.nlp = spacy.load(self.language_name, tagger=False, parser=False, entity=False)
+        self.nlp = spacy.load(self.language_name, parser=False, entity=False)
         self.featurizer = SpacyFeaturizer(self.nlp)
         self.intent_classifier = SklearnIntentClassifier()
         self.entity_extractor = SpacyEntityExtractor()

--- a/src/visualize.py
+++ b/src/visualize.py
@@ -36,7 +36,7 @@ class VisualizationRequestHandler(BaseHTTPRequestHandler):
         data_file = sys.argv[1]
         training_data = TrainingData(data_file, 'mitie', 'en')
         data = create_html(training_data)
-        self.wfile.write(data)
+        self.wfile.write(data.encode('utf-8'))
         return
 
 


### PR DESCRIPTION
- Avoid setting `tagger` to `True` during spacy creation
- Properly visualize umlauts 