### PR TITLE
Fix for #72 - Error running sklearn backend on windows

### DIFF
--- a/src/trainers/spacy_sklearn_trainer.py
+++ b/src/trainers/spacy_sklearn_trainer.py
@@ -56,7 +56,7 @@ class SpacySklearnTrainer(Trainer):
 
         with open(data_file, 'w') as f:
             f.write(self.training_data.as_json(indent=2))
-        with open(classifier_file, 'w') as f:
+        with open(classifier_file, 'wb') as f:
             cloudpickle.dump(self.intent_classifier, f)
         with open(entity_extractor_config_file, 'w') as f:
             json.dump(self.entity_extractor.ner.cfg, f)


### PR DESCRIPTION
Issue - #72 
The error occurred because the `intent_classifier.pkl` file was not opened in binary mode while writing. As per [python docs](https://docs.python.org/2/tutorial/inputoutput.html#reading-and-writing-files) Windows makes a distinction between text and binary files. Changed the code to now open the file as binary - 
`open(classifier_file, 'wb')`