### PR TITLE
Fixed vector calculation in spacy featurizer. ignore unknown words

### DIFF
--- a/src/featurizers/spacy_featurizer.py
+++ b/src/featurizers/spacy_featurizer.py
@@ -11,8 +11,10 @@ class SpacyFeaturizer(object):
         X = np.zeros((len(sentences), self.ndim))
         for idx, sentence in enumerate(sentences):
             doc = self.nlp(sentence)
-            vec = np.zeros(self.ndim)
+            vec = []
             for token in doc:
-                vec += token.vector
-            X[idx, :] = vec / len(doc)
+                if token.has_vector:
+                    vec.append(token.vector)
+            if vec:
+                X[idx, :] = np.sum(vec, axis=0) / len(vec)
         return X


### PR DESCRIPTION
If a vector doesn't have a word vector assigned, it reduces the mean during average document vector calculation. This PR fixes this and ignores words without assigned vectors.