### PR TITLE
Add scipy requirement for train to work in docker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ boto3
 pytest-pep8
 requests
 progressbar
+scipy==0.18.1


### PR DESCRIPTION
Currently building the docker image and running train will not work due to the lack of scipy, adding it to requirements fixes that.