### PR TITLE
Docker entrypoint script fix

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,10 +41,10 @@ function download_package {
 
 case ${1} in
     start)
-        python -m rasa_nlu.server "${@:2}" 
+        exec python -m rasa_nlu.server "${@:2}" 
         ;;
     run)
-        "${@:2}"
+        exec "${@:2}"
         ;;
     download)
         download_package ${@:2}


### PR DESCRIPTION
Use exec in entrypoint.sh so that it is replaced by python or whatever is started in the container. This makes sure that any signals are passed to python and not the entrypoint shell script.