### PR TITLE
Gracefully shutdown server on SIGTERM in addition to SIGINT

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -6,6 +6,7 @@ import multiprocessing
 import glob
 import warnings
 import logging
+import signal
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 from rasa_nlu.train import do_train
 from rasa_nlu.config import RasaNLUConfig
@@ -244,7 +245,12 @@ if __name__ == "__main__":
     logging.captureWarnings(True)
     logging.debug(config.view())
     try:
+        def stop(signal_number, frame):
+            raise KeyboardInterrupt()
+
+        signal.signal(signal.SIGTERM, stop)
         server = RasaNLUServer(config)
         server.start()
+
     except KeyboardInterrupt:
         server.stop()


### PR DESCRIPTION
This ensure that docker stop/restart etc which sends a SIGTERM signal will cause a graceful shutdown, saving log files and such. Previously docker stop will eventually have to simply kill the container, and log files will not be persisted.