### PR TITLE
Fixed configuration and data file paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ out/
 rasa_nlu_logs.json
 tmp_training_data.json
 .DS_Store
+model_*

--- a/config_mitie.json
+++ b/config_mitie.json
@@ -2,5 +2,5 @@
   "backend": "mitie",
   "mitie_file": "./data/total_word_feature_extractor.dat",
   "path" : "./",
-  "data" : "./data/demo-restaurants.json"
+  "data" : "./data/examples/rasa/demo-rasa.json"
 }

--- a/config_spacy.json
+++ b/config_spacy.json
@@ -1,5 +1,5 @@
 {
   "backend": "spacy_sklearn",
   "path" : "./",
-  "data" : "./data/demo-restaurants.json"
+  "data" : "./data/examples/rasa/demo-rasa.json"
 }

--- a/data/README.md
+++ b/data/README.md
@@ -3,7 +3,10 @@ They are in the format of the services rasa NLU can emulate, e.g. when you downl
 of your app from one of these services it should look like one of these files.
 
 
-demo-rasa.json : this is in the native rasa NLU format
-demo-restaurants.json : in LUIS format
-demo-flights.json : in wit format
-restaurantBot : this is a dir and in api.ai format
+[examples/rasa](examples/rasa): examples in the native rasa NLU format
+
+[examples/luis](examples/luis): in LUIS format
+
+[examples/wit](examples/wit): in wit format
+
+[examples/api](examples/api): this is a dir and in api.ai format

--- a/docs/closeloop.rst
+++ b/docs/closeloop.rst
@@ -1,11 +1,12 @@
 .. _section_closeloop:
 
 Closing the loop: improving your models from feedback
-====================================
+======================================================
 
 
 
 When the rasa_nlu server is running, it keeps track of all the predictions it's made and saves these to a log file. 
 By default this is called ``rasa_nlu_log.json``
 You can fix any incorrect predictions and add them to your training set to improve your parser.
-After adding these to your training data, but before retraining your model, it is strongly recommended that you use the visualizer to spot any errors, see :ref:`Visualizing training data <visualizing-the-training-data>`.
+After adding these to your training data, but before retraining your model, it is strongly recommended that you use the
+visualizer to spot any errors, see :ref:`Visualizing training data <visualizing-the-training-data>`.

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -7,13 +7,32 @@ Please create an issue before doing any work to avoid disappointment
 
 
 Python Conventions
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^
 
 Python code should follow the pep-8 spec. 
-
 
 Code of conduct
 ^^^^^^^^^^^^^^^^
 
 rasa NLU adheres to the `Contributor Covenant Code of Conduct <http://contributor-covenant.org/version/1/4/>`_.
 By participating, you are expected to uphold this code.
+
+Documentation
+^^^^^^^^^^^^^^^^
+Everything should be properly documented. To locally test the documentation you need to install
+
+.. code-block:: bash
+
+    brew install sphinx
+    pip install sphinx_rtd_theme
+
+After that, you can compile and view the documentation using:
+
+.. code-block:: bash
+
+    cd docs
+    make html
+    cd _build/html
+    python -m SimpleHTTPServer 8000 .
+
+The documentation will be running on http://localhost:8000/.

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -24,7 +24,7 @@ Endpoints
 -------------------------
 
 ``POST /parse`` (no emulation)
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 you must POST data in this format ``'{"q":"<your text to parse>"}'``, you can do this with
 
@@ -41,7 +41,7 @@ this starts a separate process which you can monitor with the ``/status`` endpoi
 
 .. code-block:: console
 
-    $ curl -XPOST localhost:5000/train -d @data/demo-restaurants.json
+    $ curl -XPOST localhost:5000/train -d @data/examples/rasa/demo-rasa.json
 
 
 ``GET /status``

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -36,7 +36,7 @@ api.ai
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 api app exports generate multiple files rather than just one. 
-Put them all in a directory (see ``data/restaurantBot`` in the repo) 
+Put them all in a directory (see ``data/examples/api`` in the repo)
 and pass that path to the trainer. 
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -3,7 +3,7 @@
 .. _tutorial:
 
 Tutorial: building a restaurant search bot
-====================================
+==========================================
 
 Note: see :ref:`section_migration` for how to clone your existing wit/LUIS/api.ai app.
 
@@ -64,11 +64,12 @@ Download the file and open it, and you'll see a list of training examples like t
       ]
     }
 
-hopefully the format is intuitive if you've read this far into the tutorial, for details see :ref:`section_dataformat`
+hopefully the format is intuitive if you've read this far into the tutorial, for details see :ref:`section_dataformat`.
 
 In your working directory, create a ``data`` folder, and copy the ``demo-rasa.json`` file there.
 
 .. _visualizing-the-training-data:
+
 Visualizing the Training Data
 ------------------------------------
 
@@ -92,51 +93,28 @@ Now we're going to create a configuration file. Make sure first that you've set 
 Create a file called ``config.json`` in your working directory which looks like this
 
  
-.. code-block:: json
-
-    {
-      "backend": "spacy_sklearn",
-      "path" : "./",
-      "data" : "./data/demo-restaurants.json"
-    }
+.. literalinclude:: ../config_spacy.json
+    :language: json
 
 or if you've installed the MITIE backend instead:
 
  
-.. code-block:: json
+.. literalinclude:: ../config_mitie.json
+    :language: json
 
-    {
-      "backend": "mitie",
-      "path" : "./",
-      "mitie_file" : "path/to/total_word_feature_extractor.dat",
-      "data" : "./data/demo-restaurants.json"
-    }
-
-Now we can train the model by running:
+Now we can train a spacy model by running:
 
 .. code-block:: console
 
-    $ python -m rasa_nlu.train -c config.json
+    $ python -m rasa_nlu.train -c config_spacy.json
 
 After a few minutes, rasa NLU will finish training, and you'll see a new dir called something like ``model_YYYYMMDD-HHMMSS`` with the timestamp when training finished. 
 
-To run your trained model, add a ``server_model_dir`` to your ``config.json``: 
-
-.. code-block:: json
-
-    {
-      "backend": "spacy_sklearn",
-      "path" : "./",
-      "data" : "./data/demo-restaurants.json",
-      "server_model_dir" : "./model_YYYYMMDD-HHMMSS"
-    }
-
-and run the server with 
-
+To run your trained model, pass the configuration value ``server_model_dir`` when running the server using
 
 .. code-block:: console
 
-    $ python -m rasa_nlu.server -c config.json
+    $ python -m rasa_nlu.server -c config_spacy.json --server_model_dir=./model_YYYYMMDD-HHMMSS
 
 you can then test our your new model by sending a request. Open a new tab/window on your terminal and run
 


### PR DESCRIPTION
- fixed configuration paths
- directly include json configuration examples into documentation instead of copying them (ensures the version in the documentation is up to date with the example files)
- fixed some `Title underline too short.` warnings
- added section to contribution page that explains how to setup and run the documentation