### PR TITLE
Multithreaded training

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: required
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ install:
   - python -m spacy.en.download all > jnk
   - python -m spacy.de.download all > jnk
   - wget -P data/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat
-script: py.test --pep8 -n2
+script: py.test --pep8 --boxed -n2

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ install:
   - python -m spacy.en.download all > jnk
   - python -m spacy.de.download all > jnk
   - wget -P data/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat
-script: py.test --pep8
+script: py.test --pep8 --boxed

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ install:
   - python -m spacy.en.download all > jnk
   - python -m spacy.de.download all > jnk
   - wget -P data/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat
-script: py.test --pep8 --boxed -n2
+script: py.test --pep8 --boxed -n0

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ install:
   - python -m spacy.en.download all > jnk
   - python -m spacy.de.download all > jnk
   - wget -P data/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat
-script: py.test --pep8 --boxed
+script: py.test --pep8 -n2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: required
+cache: pip
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"

--- a/_pytest/test_config.py
+++ b/_pytest/test_config.py
@@ -12,6 +12,7 @@ defaults = {
   "log_file": None,
   "log_level": logging.INFO,
   "mitie_file": "./data/total_word_feature_extractor.dat",
+  "num_threads": 1,
   "path": os.getcwd(),
   "port": 5000,
   "server_model_dir": None,

--- a/_pytest/test_config.py
+++ b/_pytest/test_config.py
@@ -1,3 +1,5 @@
+import tempfile
+
 from rasa_nlu.config import RasaNLUConfig
 import json
 import os
@@ -30,48 +32,52 @@ def test_blank_config():
     file_config = {}
     cmdline_args = {}
     env_vars = {}
-    result = {}
-    with open('tmp_config_file.json', 'w') as f:
+    with tempfile.NamedTemporaryFile(suffix="_tmp_config_file.json") as f:
         f.write(json.dumps(file_config))
-    final_config = RasaNLUConfig('tmp_config_file.json', env_vars, cmdline_args)
-    assert dict(final_config.items()) == defaults
+        f.flush()
+        final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+        assert dict(final_config.items()) == defaults
 
 
 def test_file_config_unchanged():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {}
     env_vars = {}
-    with open('tmp_config_file.json', 'w') as f:
+    with tempfile.NamedTemporaryFile(suffix="_tmp_config_file.json") as f:
         f.write(json.dumps(file_config))
-    final_config = RasaNLUConfig('tmp_config_file.json', env_vars, cmdline_args)
-    assert final_config.path == "/path/to/dir"
+        f.flush()
+        final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+        assert final_config['path'] == "/path/to/dir"
 
 
 def test_cmdline_overrides_init():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {"path": "/alternate/path"}
     env_vars = {}
-    with open('tmp_config_file.json', 'w') as f:
+    with tempfile.NamedTemporaryFile(suffix="_tmp_config_file.json") as f:
         f.write(json.dumps(file_config))
-    final_config = RasaNLUConfig('tmp_config_file.json', env_vars, cmdline_args)
-    assert final_config.path == "/alternate/path"
+        f.flush()
+        final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+        assert final_config['path'] == "/alternate/path"
 
 
 def test_envvar_overrides_init():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {}
     env_vars = {"RASA_PATH": "/alternate/path"}
-    with open('tmp_config_file.json', 'w') as f:
+    with tempfile.NamedTemporaryFile(suffix="_tmp_config_file.json") as f:
         f.write(json.dumps(file_config))
-    final_config = RasaNLUConfig('tmp_config_file.json', env_vars, cmdline_args)
-    assert final_config.path == "/alternate/path"
+        f.flush()
+        final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+        assert final_config['path'] == "/alternate/path"
 
 
 def test_cmdline_overrides_envvar():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {"path": "/another/path"}
     env_vars = {"RASA_PATH": "/alternate/path"}
-    with open('tmp_config_file.json', 'w') as f:
+    with tempfile.NamedTemporaryFile(suffix="_tmp_config_file.json") as f:
         f.write(json.dumps(file_config))
-    final_config = RasaNLUConfig('tmp_config_file.json', env_vars, cmdline_args)
-    assert final_config.path == "/another/path"
+        f.flush()
+        final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+        assert final_config['path'] == "/another/path"

--- a/_pytest/test_featurizers.py
+++ b/_pytest/test_featurizers.py
@@ -27,7 +27,7 @@ def test_mitie():
     from rasa_nlu.featurizers.mitie_featurizer import MITIEFeaturizer
 
     filename = os.environ.get('MITIE_FILE')
-    if (filename and os.path.isfile(filename)):
+    if filename and os.path.isfile(filename):
         ftr = MITIEFeaturizer(os.environ.get('MITIE_FILE'))
         sentence = "Hey how are you today"
         vecs = ftr.create_bow_vecs([sentence])

--- a/_pytest/test_train.py
+++ b/_pytest/test_train.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import tempfile
 
 import pytest
 import os
@@ -11,13 +12,17 @@ def run_train(_config):
     do_train(config)
 
 
+def temp_log_file_location():
+    return tempfile.mkstemp(suffix="_rasa_nlu_logs.json")[1]
+
+
 def test_train_mitie():
     # basic conf
     _config = {
-        'write': os.path.join(os.getcwd(), "rasa_nlu_logs.json"),
+        'write': temp_log_file_location(),
         'port': 5022,
         "backend": "mitie",
-        "path": "./",
+        "path": tempfile.mkdtemp(),
         "data": "./data/examples/rasa/demo-rasa.json"
     }
     run_train(_config)
@@ -26,10 +31,10 @@ def test_train_mitie():
 def test_train_mitie_noents():
     # basic conf
     _config = {
-        'write': os.path.join(os.getcwd(), "rasa_nlu_logs.json"),
+        'write': temp_log_file_location(),
         'port': 5022,
         "backend": "mitie",
-        "path": "./",
+        "path": tempfile.mkdtemp(),
         "data": "./data/examples/rasa/demo-rasa-noents.json"
     }
     run_train(_config)
@@ -38,10 +43,10 @@ def test_train_mitie_noents():
 def test_train_mitie_multithread():
     # basic conf
     _config = {
-        'write': os.path.join(os.getcwd(), "rasa_nlu_logs.json"),
+        'write': temp_log_file_location(),
         'port': 5022,
         "backend": "mitie",
-        "path": "./",
+        "path": tempfile.mkdtemp(),
         "num_threads": 2,
         "data": "./data/examples/rasa/demo-rasa.json"
     }
@@ -51,10 +56,10 @@ def test_train_mitie_multithread():
 def test_train_spacy_sklearn():
     # basic conf
     _config = {
-        'write': os.path.join(os.getcwd(), "rasa_nlu_logs.json"),
+        'write': temp_log_file_location(),
         'port': 5022,
         "backend": "spacy_sklearn",
-        "path": "./",
+        "path": tempfile.mkdtemp(),
         "data": "./data/examples/rasa/demo-rasa.json"
     }
     run_train(_config)
@@ -63,10 +68,10 @@ def test_train_spacy_sklearn():
 def test_train_spacy_sklearn_noents():
     # basic conf
     _config = {
-        'write': os.path.join(os.getcwd(), "rasa_nlu_logs.json"),
+        'write': temp_log_file_location(),
         'port': 5022,
         "backend": "spacy_sklearn",
-        "path": "./",
+        "path": tempfile.mkdtemp(),
         "data": "./data/examples/rasa/demo-rasa-noents.json"
     }
     run_train(_config)
@@ -75,10 +80,10 @@ def test_train_spacy_sklearn_noents():
 def test_train_spacy_sklearn_multithread():
     # basic conf
     _config = {
-        'write': os.path.join(os.getcwd(), "rasa_nlu_logs.json"),
+        'write': temp_log_file_location(),
         'port': 5022,
         "backend": "spacy_sklearn",
-        "path": "./",
+        "path": tempfile.mkdtemp(),
         "num_threads": 2,
         "data": "./data/examples/rasa/demo-rasa.json"
     }

--- a/_pytest/test_train.py
+++ b/_pytest/test_train.py
@@ -42,7 +42,7 @@ def test_train_mitie_multithread():
         'port': 5022,
         "backend": "mitie",
         "path": "./",
-        "num_threads": 8,
+        "num_threads": 2,
         "data": "./data/examples/rasa/demo-rasa.json"
     }
     run_train(_config)
@@ -79,7 +79,7 @@ def test_train_spacy_sklearn_multithread():
         'port': 5022,
         "backend": "spacy_sklearn",
         "path": "./",
-        "num_threads": 8,
+        "num_threads": 2,
         "data": "./data/examples/rasa/demo-rasa.json"
     }
     run_train(_config)

--- a/_pytest/test_train.py
+++ b/_pytest/test_train.py
@@ -34,6 +34,7 @@ def test_train_mitie_noents():
     }
     run_train(_config)
 
+
 def test_train_mitie_multithread():
     # basic conf
     _config = {
@@ -69,6 +70,7 @@ def test_train_spacy_sklearn_noents():
         "data": "./data/examples/rasa/demo-rasa-noents.json"
     }
     run_train(_config)
+
 
 def test_train_spacy_sklearn_multithread():
     # basic conf

--- a/_pytest/test_train.py
+++ b/_pytest/test_train.py
@@ -34,6 +34,18 @@ def test_train_mitie_noents():
     }
     run_train(_config)
 
+def test_train_mitie_multithread():
+    # basic conf
+    _config = {
+        'write': os.path.join(os.getcwd(), "rasa_nlu_logs.json"),
+        'port': 5022,
+        "backend": "mitie",
+        "path": "./",
+        "num_threads": 8,
+        "data": "./data/examples/rasa/demo-rasa.json"
+    }
+    run_train(_config)
+
 
 def test_train_spacy_sklearn():
     # basic conf
@@ -55,5 +67,17 @@ def test_train_spacy_sklearn_noents():
         "backend": "spacy_sklearn",
         "path": "./",
         "data": "./data/examples/rasa/demo-rasa-noents.json"
+    }
+    run_train(_config)
+
+def test_train_spacy_sklearn_multithread():
+    # basic conf
+    _config = {
+        'write': os.path.join(os.getcwd(), "rasa_nlu_logs.json"),
+        'port': 5022,
+        "backend": "spacy_sklearn",
+        "path": "./",
+        "num_threads": 8,
+        "data": "./data/examples/rasa/demo-rasa.json"
     }
     run_train(_config)

--- a/_pytest/test_train.py
+++ b/_pytest/test_train.py
@@ -3,7 +3,7 @@
 import pytest
 import os
 from rasa_nlu.config import RasaNLUConfig
-from rasa_nlu.server import do_train
+from rasa_nlu.train import do_train
 
 
 def run_train(_config):

--- a/_pytest/test_training_data.py
+++ b/_pytest/test_training_data.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import os
+import tempfile
+
 from rasa_nlu.training_data import TrainingData
 from rasa_nlu.trainers.mitie_trainer import MITIETrainer
 
@@ -44,17 +47,17 @@ def test_repeated_entities():
     ]
   }
 }"""
-    filename = 'tmp_training_data.json'
-    with open(filename, 'w') as f:
+    with tempfile.NamedTemporaryFile(suffix="_tmp_training_data.json") as f:
         f.write(data.encode("utf-8"))
-    td = TrainingData(filename, 'mitie', 'en')
-    assert len(td.entity_examples) == 1
-    example = td.entity_examples[0]
-    entities = example["entities"]
-    assert len(entities) == 1
-    start, end = MITIETrainer.find_entity(entities[0], example["text"])
-    assert start == 9
-    assert end == 10
+        f.flush()
+        td = TrainingData(f.name, 'mitie', 'en')
+        assert len(td.entity_examples) == 1
+        example = td.entity_examples[0]
+        entities = example["entities"]
+        assert len(entities) == 1
+        start, end = MITIETrainer.find_entity(entities[0], example["text"])
+        assert start == 9
+        assert end == 10
 
 
 def test_multiword_entities():
@@ -77,17 +80,17 @@ def test_multiword_entities():
     ]
   }
 }"""
-    filename = 'tmp_training_data.json'
-    with open(filename, 'w') as f:
+    with tempfile.NamedTemporaryFile(suffix="_tmp_training_data.json") as f:
         f.write(data.encode("utf-8"))
-    td = TrainingData(filename, 'mitie', 'en')
-    assert len(td.entity_examples) == 1
-    example = td.entity_examples[0]
-    entities = example["entities"]
-    assert len(entities) == 1
-    start, end = MITIETrainer.find_entity(entities[0], example["text"])
-    assert start == 4
-    assert end == 7
+        f.flush()
+        td = TrainingData(f.name, 'mitie', 'en')
+        assert len(td.entity_examples) == 1
+        example = td.entity_examples[0]
+        entities = example["entities"]
+        assert len(entities) == 1
+        start, end = MITIETrainer.find_entity(entities[0], example["text"])
+        assert start == 4
+        assert end == 7
 
 
 def test_nonascii_entities():
@@ -108,16 +111,16 @@ def test_nonascii_entities():
     }
   ]
 }"""
-    filename = 'tmp_training_data.json'
-    with open(filename, 'w') as f:
+    with tempfile.NamedTemporaryFile(suffix="_tmp_training_data.json") as f:
         f.write(data.encode("utf-8"))
-    td = TrainingData(filename, 'mitie', 'en')
-    assert len(td.entity_examples) == 1
-    example = td.entity_examples[0]
-    entities = example["entities"]
-    assert len(entities) == 1
-    entity = entities[0]
-    assert entity["value"] == u"ßäæ ?€ö)"
-    assert entity["start"] == 19
-    assert entity["end"] == 27
-    assert entity["entity"] == "description"
+        f.flush()
+        td = TrainingData(f.name, 'mitie', 'en')
+        assert len(td.entity_examples) == 1
+        example = td.entity_examples[0]
+        entities = example["entities"]
+        assert len(entities) == 1
+        entity = entities[0]
+        assert entity["value"] == u"ßäæ ?€ö)"
+        assert entity["start"] == 19
+        assert entity["end"] == 27
+        assert entity["entity"] == "description"

--- a/_pytest/trainers/test_mitie_trainer.py
+++ b/_pytest/trainers/test_mitie_trainer.py
@@ -7,4 +7,4 @@ class TestMitieTrainer:
     def test_failure_on_invalid_lang(self):
         config = RasaNLUConfig("config_mitie.json")
         with pytest.raises(NotImplementedError):
-            MITIETrainer(config.mitie_file, 'umpalumpa')
+            MITIETrainer(config['mitie_file'], 'umpalumpa')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ cloudpickle
 boto3
 pytest-pep8
 pytest-xdist
+pytest-services
 requests
 progressbar
 scipy==0.18.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pathlib
 cloudpickle
 boto3
 pytest-pep8
+pytest-xdist
 requests
 progressbar
 scipy==0.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 pep8maxlinelength = 120
 pep8ignore =
     docs/conf.py ALL
-addopts = --boxed
+addopts = --boxed -n4
 
 [metadata]
 description-file = README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 pep8maxlinelength = 120
 pep8ignore =
     docs/conf.py ALL
-addopts = --boxed -n4
+addopts = -n4
 
 [metadata]
 description-file = README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@
 pep8maxlinelength = 120
 pep8ignore =
     docs/conf.py ALL
+addopts = --boxed
 
 [metadata]
 description-file = README.md

--- a/src/classifiers/sklearn_intent_classifier.py
+++ b/src/classifiers/sklearn_intent_classifier.py
@@ -10,11 +10,12 @@ from sklearn.svm import SVC
 class SklearnIntentClassifier(object):
     """Intent classifier using the sklearn framework"""
 
-    def __init__(self, uses_probabilities=True):
+    def __init__(self, uses_probabilities=True, max_num_threads=1):
         """Construct a new intent classifier using the sklearn framework.
 
         :param uses_probabilities: defines if the model should be trained
                                            to be able to predict label probabilities
+        :param max_num_threads: number of threads used during training time
         :type uses_probabilities: bool"""
 
         self.le = LabelEncoder()
@@ -22,7 +23,8 @@ class SklearnIntentClassifier(object):
         self.tuned_parameters = [{'C': [1, 2, 5, 10, 20, 100], 'kernel': ['linear']}]
         self.score = 'f1'
         self.clf = GridSearchCV(SVC(C=1, probability=uses_probabilities),
-                                self.tuned_parameters, cv=2, scoring='%s_weighted' % self.score)
+                                self.tuned_parameters, n_jobs= max_num_threads,
+                                cv=2, scoring='%s_weighted' % self.score)
 
     def transform_labels_str2num(self, labels):
         """Transforms a list of strings into numeric label representation.

--- a/src/classifiers/sklearn_intent_classifier.py
+++ b/src/classifiers/sklearn_intent_classifier.py
@@ -23,7 +23,7 @@ class SklearnIntentClassifier(object):
         self.tuned_parameters = [{'C': [1, 2, 5, 10, 20, 100], 'kernel': ['linear']}]
         self.score = 'f1'
         self.clf = GridSearchCV(SVC(C=1, probability=uses_probabilities),
-                                self.tuned_parameters, n_jobs= max_num_threads,
+                                self.tuned_parameters, n_jobs=max_num_threads,
                                 cv=2, scoring='%s_weighted' % self.score)
 
     def transform_labels_str2num(self, labels):

--- a/src/config.py
+++ b/src/config.py
@@ -17,6 +17,7 @@ class RasaNLUConfig(object):
           "log_file": None,
           "log_level": logging.INFO,
           "mitie_file": "./data/total_word_feature_extractor.dat",
+          "num_threads": 1,
           "path": os.getcwd(),
           "port": 5000,
           "server_model_dir": None,

--- a/src/train.py
+++ b/src/train.py
@@ -17,7 +17,8 @@ def create_argparser():
     parser.add_argument('-d', '--data', default=None, help="file containing training data")
     parser.add_argument('-c', '--config', required=True, help="config file")
     parser.add_argument('-l', '--language', default=None, choices=['de', 'en'], help="model and data language")
-    parser.add_argument('-t', '--num_threads', default=1, type=int, help="number of threads to use during model training")
+    parser.add_argument('-t', '--num_threads', default=1, type=int,
+                        help="number of threads to use during model training")
     parser.add_argument('-m', '--mitie_file', default=None,
                         help='file with mitie total_word_feature_extractor')
     return parser

--- a/src/train.py
+++ b/src/train.py
@@ -17,6 +17,7 @@ def create_argparser():
     parser.add_argument('-d', '--data', default=None, help="file containing training data")
     parser.add_argument('-c', '--config', required=True, help="config file")
     parser.add_argument('-l', '--language', default=None, choices=['de', 'en'], help="model and data language")
+    parser.add_argument('-t', '--num_threads', default=1, type=int, help="number of threads to use during model training")
     parser.add_argument('-m', '--mitie_file', default=None,
                         help='file with mitie total_word_feature_extractor')
     return parser
@@ -26,10 +27,10 @@ def create_trainer(config):
     backend = config.backend.lower()
     if backend == 'mitie':
         from trainers.mitie_trainer import MITIETrainer
-        return MITIETrainer(config.mitie_file, config.language)
+        return MITIETrainer(config.mitie_file, config.language, config.num_threads)
     if backend == 'spacy_sklearn':
         from trainers.spacy_sklearn_trainer import SpacySklearnTrainer
-        return SpacySklearnTrainer(config, config.language)
+        return SpacySklearnTrainer(config, config.language, config.num_threads)
     else:
         raise NotImplementedError("other backend trainers not implemented yet")
 

--- a/src/trainers/mitie_trainer.py
+++ b/src/trainers/mitie_trainer.py
@@ -12,12 +12,13 @@ from rasa_nlu.tokenizers.mitie_tokenizer import MITIETokenizer
 class MITIETrainer(Trainer):
     SUPPORTED_LANGUAGES = {"en"}
 
-    def __init__(self, fe_file, language_name):
+    def __init__(self, fe_file, language_name, max_num_threads=1):
         self.name = "mitie"
         self.training_data = None
         self.intent_classifier = None
         self.entity_extractor = None
         self.training_data = None
+        self.max_num_threads = max_num_threads
         self.fe_file = fe_file
         self.ensure_language_support(language_name)
 
@@ -45,6 +46,7 @@ class MITIETrainer(Trainer):
 
     def train_entity_extractor(self, entity_examples):
         trainer = ner_trainer(self.fe_file)
+        trainer.num_threads = self.max_num_threads
         for example in entity_examples:
             text = example["text"]
             tokens = tokenize(text)
@@ -60,6 +62,7 @@ class MITIETrainer(Trainer):
 
     def train_intent_classifier(self, intent_examples):
         trainer = text_categorizer_trainer(self.fe_file)
+        trainer.num_threads = self.max_num_threads
         for example in intent_examples:
             tokens = tokenize(example["text"])
             trainer.add_labeled_text(tokens, example["intent"])

--- a/src/trainers/mitie_trainer.py
+++ b/src/trainers/mitie_trainer.py
@@ -70,19 +70,24 @@ class MITIETrainer(Trainer):
         intent_classifier = trainer.train()
         return intent_classifier
 
-    def persist(self, path, persistor=None):
-        tstamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
-        dirname = os.path.join(path, "model_" + tstamp)
-        os.mkdir(dirname)
-        data_file = os.path.join(dirname, "training_data.json")
+    def persist(self, path, persistor=None, create_unique_subfolder=True):
+        timestamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
+
+        if create_unique_subfolder:
+            dir_name = os.path.join(path, "model_" + timestamp)
+            os.mkdir(dir_name)
+        else:
+            dir_name = path
+
+        data_file = os.path.join(dir_name, "training_data.json")
 
         classifier_file, entity_extractor_file = None, None
         if self.intent_classifier:
-            classifier_file = os.path.join(dirname, "intent_classifier.dat")
+            classifier_file = os.path.join(dir_name, "intent_classifier.dat")
         if self.entity_extractor:
-            entity_extractor_file = os.path.join(dirname, "entity_extractor.dat")
+            entity_extractor_file = os.path.join(dir_name, "entity_extractor.dat")
 
-        write_training_metadata(dirname, tstamp, data_file, self.name, 'en',
+        write_training_metadata(dir_name, timestamp, data_file, self.name, 'en',
                                 classifier_file, entity_extractor_file, self.fe_file)
 
         with open(data_file, 'w') as f:
@@ -94,4 +99,4 @@ class MITIETrainer(Trainer):
             self.entity_extractor.save_to_disk(entity_extractor_file, pure_model=True)
 
         if persistor is not None:
-            persistor.send_tar_to_s3(dirname)
+            persistor.send_tar_to_s3(dir_name)

--- a/src/trainers/spacy_sklearn_trainer.py
+++ b/src/trainers/spacy_sklearn_trainer.py
@@ -14,10 +14,11 @@ from training_utils import write_training_metadata
 class SpacySklearnTrainer(Trainer):
     SUPPORTED_LANGUAGES = {"en", "de"}
 
-    def __init__(self, config, language_name):
+    def __init__(self, config, language_name, max_num_threads=1):
         self.ensure_language_support(language_name)
         self.name = "spacy_sklearn"
         self.language_name = language_name
+        self.max_num_threads = max_num_threads
         self.training_data = None
         self.nlp = spacy.load(self.language_name, parser=False, entity=False)
         self.featurizer = SpacyFeaturizer(self.nlp)
@@ -37,7 +38,7 @@ class SpacySklearnTrainer(Trainer):
         self.entity_extractor.train(self.nlp, entity_examples)
 
     def train_intent_classifier(self, intent_examples, test_split_size=0.1):
-        self.intent_classifier = SklearnIntentClassifier()
+        self.intent_classifier = SklearnIntentClassifier(max_num_threads=self.max_num_threads)
         labels = [e["intent"] for e in intent_examples]
         sentences = [e["text"] for e in intent_examples]
         y = self.intent_classifier.transform_labels_str2num(labels)


### PR DESCRIPTION
- use multiple threads during training
- new option `-t` to specify number of threads
- spacy will only use multiple threads during intent classification - not during entity training
- small fix to save mitie models in the same way as spacy (added `create_unique_subfolder` option)