### PR TITLE
Raise proper errors on if spacy is not loaded

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name='rasa_nlu',
     packages=[
         'rasa_nlu',
+        'rasa_nlu.utils',
         'rasa_nlu.classifiers',
         'rasa_nlu.emulators',
         'rasa_nlu.extractors',

--- a/src/interpreters/spacy_sklearn_interpreter.py
+++ b/src/interpreters/spacy_sklearn_interpreter.py
@@ -4,6 +4,7 @@ import spacy
 from rasa_nlu import Interpreter
 from rasa_nlu.extractors.spacy_entity_extractor import SpacyEntityExtractor
 from rasa_nlu.featurizers.spacy_featurizer import SpacyFeaturizer
+from rasa_nlu.utils.spacy import ensure_proper_language_model
 
 
 class SpacySklearnInterpreter(Interpreter):
@@ -12,6 +13,9 @@ class SpacySklearnInterpreter(Interpreter):
         self.classifier = None
         self.nlp = spacy.load(language_name, parser=False, entity=False, matcher=False)
         self.featurizer = SpacyFeaturizer(self.nlp)
+
+        ensure_proper_language_model(self.nlp)
+
         if intent_classifier:
             with open(intent_classifier, 'rb') as f:
                 self.classifier = cloudpickle.load(f)

--- a/src/trainers/spacy_sklearn_trainer.py
+++ b/src/trainers/spacy_sklearn_trainer.py
@@ -9,6 +9,7 @@ from rasa_nlu.classifiers.sklearn_intent_classifier import SklearnIntentClassifi
 from rasa_nlu.extractors.spacy_entity_extractor import SpacyEntityExtractor
 from rasa_nlu.trainers.trainer import Trainer
 from training_utils import write_training_metadata
+from rasa_nlu.utils.spacy import ensure_proper_language_model
 
 
 class SpacySklearnTrainer(Trainer):
@@ -23,6 +24,7 @@ class SpacySklearnTrainer(Trainer):
         self.featurizer = SpacyFeaturizer(self.nlp)
         self.intent_classifier = None
         self.entity_extractor = None
+        ensure_proper_language_model(self.nlp)
 
     def train(self, data, test_split_size=0.1):
         self.training_data = data

--- a/src/trainers/trainer.py
+++ b/src/trainers/trainer.py
@@ -3,5 +3,5 @@ class Trainer(object):
 
     def ensure_language_support(self, language_name):
         if language_name not in self.SUPPORTED_LANGUAGES:
-            raise NotImplementedError("MITIE backend currently does not support language '{}' (only '{}')."
+            raise NotImplementedError("Selected backend currently does not support language '{}' (only '{}')."
                                       .format(language_name, "', '".join(self.SUPPORTED_LANGUAGES)))

--- a/src/utils/spacy.py
+++ b/src/utils/spacy.py
@@ -1,0 +1,9 @@
+def ensure_proper_language_model(nlp):
+    """Checks if the spacy language model is properly loaded. Raises an exception if the model is invalid."""
+
+    if nlp is None:
+        raise Exception("Failed to load spacy language model. Loading the model returned 'None'.")
+    if nlp.path is None:
+        # Spacy sets the path to `None` if it did not load the model from disk. In this case `nlp` is an unusable stub.
+        raise Exception("Failed to load spacy language model for lang '{}'. ".format(nlp.lang) +
+                        "Make sure you have downloaded the correct model (https://spacy.io/docs/usage/).")


### PR DESCRIPTION
If spacy did not properly load a model (e.g. if the user missed to download the language files) an exception is thrown. Previously the training would succeed without error and running the model would lead to uninformative exceptions (see #145).