### PR TITLE
Provide option to fine tune spacy NER model instead of training from scratch

### DIFF
--- a/_pytest/test_config.py
+++ b/_pytest/test_config.py
@@ -15,6 +15,7 @@ defaults = {
   "log_level": logging.INFO,
   "mitie_file": "./data/total_word_feature_extractor.dat",
   "num_threads": 1,
+  "fine_tune_spacy_ner": False,
   "path": os.getcwd(),
   "port": 5000,
   "server_model_dir": None,

--- a/_pytest/test_train.py
+++ b/_pytest/test_train.py
@@ -37,7 +37,9 @@ def test_train_mitie_sklearn():
         "path": "./",
         "data": "./data/examples/rasa/demo-rasa.json"
     }
-    run_train(_config)
+    trained = run_train(_config)
+    assert trained.entity_extractor is not None
+    assert trained.intent_classifier is not None
 
 
 def test_train_mitie_noents():

--- a/_pytest/test_train.py
+++ b/_pytest/test_train.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 import tempfile
 
-import pytest
-import os
 from rasa_nlu.config import RasaNLUConfig
 from rasa_nlu.train import do_train
 
 
 def run_train(_config):
     config = RasaNLUConfig(cmdline_args=_config)
-    do_train(config)
+    return do_train(config)
 
 
 def temp_log_file_location():
@@ -25,7 +23,9 @@ def test_train_mitie():
         "path": tempfile.mkdtemp(),
         "data": "./data/examples/rasa/demo-rasa.json"
     }
-    run_train(_config)
+    trained = run_train(_config)
+    assert trained.entity_extractor is not None
+    assert trained.intent_classifier is not None
 
 
 def test_train_mitie_sklearn():
@@ -49,7 +49,9 @@ def test_train_mitie_noents():
         "path": tempfile.mkdtemp(),
         "data": "./data/examples/rasa/demo-rasa-noents.json"
     }
-    run_train(_config)
+    trained = run_train(_config)
+    assert trained.entity_extractor is None
+    assert trained.intent_classifier is not None
 
 
 def test_train_mitie_multithread():
@@ -62,7 +64,9 @@ def test_train_mitie_multithread():
         "num_threads": 2,
         "data": "./data/examples/rasa/demo-rasa.json"
     }
-    run_train(_config)
+    trained = run_train(_config)
+    assert trained.entity_extractor is not None
+    assert trained.intent_classifier is not None
 
 
 def test_train_spacy_sklearn():
@@ -74,7 +78,9 @@ def test_train_spacy_sklearn():
         "path": tempfile.mkdtemp(),
         "data": "./data/examples/rasa/demo-rasa.json"
     }
-    run_train(_config)
+    trained = run_train(_config)
+    assert trained.entity_extractor is not None
+    assert trained.intent_classifier is not None
 
 
 def test_train_spacy_sklearn_noents():
@@ -86,7 +92,30 @@ def test_train_spacy_sklearn_noents():
         "path": tempfile.mkdtemp(),
         "data": "./data/examples/rasa/demo-rasa-noents.json"
     }
-    run_train(_config)
+    trained = run_train(_config)
+    assert trained.entity_extractor is None
+    assert trained.intent_classifier is not None
+
+
+def test_train_spacy_sklearn_finetune_ner():
+    # basic conf
+    _config = {
+        "write": temp_log_file_location(),
+        "port": 5022,
+        "fine_tune_spacy_ner": True,
+        "backend": "spacy_sklearn",
+        "path": tempfile.mkdtemp(),
+        "data": "./data/examples/rasa/demo-rasa.json"
+    }
+    trained = run_train(_config)
+    assert trained.entity_extractor is not None
+    assert trained.intent_classifier is not None
+
+    entities = trained.entity_extractor.extract_entities(trained.nlp, u"I am living in New York now.")
+    # Although the model is trained on restaurant entities, we can use the entities (`GPE`, `DATE`)
+    # from spacy since we are fine tuning. This should even be the case if the rasa-entity training data changes!
+    assert {u'start': 15, u'end': 23, u'value': u'New York', u'entity': u'GPE'} in entities
+    assert {u'start': 24, u'end': 27, u'value': u'now', u'entity': u'DATE'} in entities
 
 
 def test_train_spacy_sklearn_multithread():
@@ -99,4 +128,6 @@ def test_train_spacy_sklearn_multithread():
         "num_threads": 2,
         "data": "./data/examples/rasa/demo-rasa.json"
     }
-    run_train(_config)
+    trained = run_train(_config)
+    assert trained.entity_extractor is not None
+    assert trained.intent_classifier is not None

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,7 @@ class RasaNLUConfig(object):
           "log_level": logging.INFO,
           "mitie_file": "./data/total_word_feature_extractor.dat",
           "num_threads": 1,
+          "fine_tune_spacy_ner": False,
           "path": os.getcwd(),
           "port": 5000,
           "server_model_dir": None,

--- a/src/train.py
+++ b/src/train.py
@@ -34,7 +34,7 @@ def create_trainer(config):
         return MITIESklearnTrainer(config.mitie_file, config.language, config.num_threads)
     if backend == 'spacy_sklearn':
         from trainers.spacy_sklearn_trainer import SpacySklearnTrainer
-        return SpacySklearnTrainer(config.language, config.num_threads)
+        return SpacySklearnTrainer(config.language, config.num_threads, config.fine_tune_spacy_ner)
     else:
         raise NotImplementedError("other backend trainers not implemented yet")
 
@@ -56,6 +56,8 @@ def init():
 
 
 def do_train(config):
+    """Loads the trainer and the data and runs the training of the specified model."""
+
     trainer = create_trainer(config)
 
     persistor = create_persistor(config)
@@ -63,6 +65,7 @@ def do_train(config):
     training_data = TrainingData(config.data, config.backend, config.language)
     trainer.train(training_data)
     trainer.persist(config.path, persistor)
+    return trainer
 
 
 if __name__ == '__main__':

--- a/src/trainers/mitie_sklearn_trainer.py
+++ b/src/trainers/mitie_sklearn_trainer.py
@@ -45,16 +45,12 @@ class MITIESklearnTrainer(Trainer):
         else:
             dir_name = path
 
-    def persist(self, path, persistor=None):
-        tstamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
-        dirname = os.path.join(path, "model_" + tstamp)
-        os.mkdir(dirname)
-        data_file = os.path.join(dirname, "training_data.json")
-        classifier_file = os.path.join(dirname, "intent_classifier.dat")
-        entity_extractor_file = os.path.join(dirname, "entity_extractor.dat")
-        entity_synonyms_file = os.path.join(dirname, "index.json") if self.training_data.entity_synonyms else None
+        data_file = os.path.join(dir_name, "training_data.json")
+        classifier_file = os.path.join(dir_name, "intent_classifier.dat")
+        entity_extractor_file = os.path.join(dir_name, "entity_extractor.dat")
+        entity_synonyms_file = os.path.join(dir_name, "index.json") if self.training_data.entity_synonyms else None
 
-        write_training_metadata(dirname, tstamp, data_file, self.name, 'en',
+        write_training_metadata(dir_name, timestamp, data_file, self.name, 'en',
                                 classifier_file, entity_extractor_file, entity_synonyms_file,
                                 self.fe_file)
 
@@ -72,4 +68,4 @@ class MITIESklearnTrainer(Trainer):
         self.entity_extractor.save_to_disk(entity_extractor_file, pure_model=True)
 
         if persistor is not None:
-            persistor.send_tar_to_s3(dirname)
+            persistor.send_tar_to_s3(dir_name)

--- a/src/trainers/spacy_sklearn_trainer.py
+++ b/src/trainers/spacy_sklearn_trainer.py
@@ -22,7 +22,7 @@ class SpacySklearnTrainer(Trainer):
 
     def train_entity_extractor(self, entity_examples):
         self.entity_extractor = SpacyEntityExtractor()
-        self.entity_extractor = self.entity_extractor.train(self.nlp, entity_examples)
+        self.entity_extractor.train(self.nlp, entity_examples)
 
     def train_intent_classifier(self, intent_examples, test_split_size=0.1):
         self.intent_classifier = sklearn_trainer_utils.train_intent_classifier(intent_examples,

--- a/src/trainers/spacy_sklearn_trainer.py
+++ b/src/trainers/spacy_sklearn_trainer.py
@@ -14,15 +14,23 @@ from rasa_nlu.utils.spacy import ensure_proper_language_model
 class SpacySklearnTrainer(Trainer):
     SUPPORTED_LANGUAGES = {"en", "de"}
 
-    def __init__(self, language_name, max_num_threads=1):
+    def __init__(self, language_name, max_num_threads=1, should_fine_tune_spacy_ner=False):
         super(self.__class__, self).__init__("spacy_sklearn", language_name, max_num_threads)
-        self.nlp = spacy.load(self.language_name, parser=False, entity=False)
+        self.should_fine_tune_spacy_ner = should_fine_tune_spacy_ner
+        self.nlp = self._load_nlp_model(language_name, should_fine_tune_spacy_ner)
         self.featurizer = SpacyFeaturizer(self.nlp)
         ensure_proper_language_model(self.nlp)
 
     def train_entity_extractor(self, entity_examples):
         self.entity_extractor = SpacyEntityExtractor()
-        self.entity_extractor.train(self.nlp, entity_examples)
+        self.entity_extractor.train(self.nlp, entity_examples, self.should_fine_tune_spacy_ner)
+
+    def _load_nlp_model(self, language_name, should_fine_tune_spacy_ner):
+        # If fine tuning is disabled, we do not need to load the spacy entity model
+        if should_fine_tune_spacy_ner:
+            return spacy.load(language_name, parser=False)
+        else:
+            return spacy.load(language_name, parser=False, entity=False)
 
     def train_intent_classifier(self, intent_examples, test_split_size=0.1):
         self.intent_classifier = sklearn_trainer_utils.train_intent_classifier(intent_examples,


### PR DESCRIPTION
first commit:
- fixed regression of #152 (trainer `persist` got screwed up & entity extractor was not set after training)

second commit:
- improved training tests (they now check if entity extractor & intent classifier exist)
- fixes #166 (allows to fine tune spacys provided NER models with the training data)
- don't `finish` after entity training. fixes #136