### PR TITLE
Removed ./models path in --server_model_dirs

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -120,7 +120,7 @@ To run your trained model, pass the configuration value ``server_model_dirs`` wh
 
 .. code-block:: console
 
-    $ python -m rasa_nlu.server -c config_spacy.json --server_model_dirs=./models/model_YYYYMMDD-HHMMSS
+    $ python -m rasa_nlu.server -c config_spacy.json --server_model_dirs=model_YYYYMMDD-HHMMSS
 
 More information about starting the server can be found in :ref:`section_http`.
 


### PR DESCRIPTION
Launching the server fails with "./models" path prefix