### PR TITLE
Spacy 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ install:
   - source activate test-environment
   - pip install -r requirements.txt
   - python setup.py install
-  - pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-1.2.0/en_core_web_sm-1.2.0.tar.gz --no-cache-dir
-  - pip install https://github.com/explosion/spacy-models/releases/download/de_core_news_md-1.0.0/de_core_news_md-1.0.0.tar.gz --no-cache-dir
+  - pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-1.2.0/en_core_web_sm-1.2.0.tar.gz --no-cache-dir > jnk
+  - pip install https://github.com/explosion/spacy-models/releases/download/de_core_news_md-1.0.0/de_core_news_md-1.0.0.tar.gz --no-cache-dir > jnk
   - if [[ ! -f data/total_word_feature_extractor.dat ]]; then
       wget -P data/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ install:
   - source activate test-environment
   - pip install -r requirements.txt
   - python setup.py install
-  - python -m spacy.en.download all > jnk
-  - python -m spacy.de.download all > jnk
+  - python -m spacy download en > jnk
+  - python -m spacy download de > jnk
   - if [[ ! -f data/total_word_feature_extractor.dat ]]; then
       wget -P data/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ install:
   - source activate test-environment
   - pip install -r requirements.txt
   - python setup.py install
-  - python -m spacy download en > jnk
-  - python -m spacy download de > jnk
+  - pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-1.2.0/en_core_web_sm-1.2.0.tar.gz --no-cache-dir
+  - pip install https://github.com/explosion/spacy-models/releases/download/de_core_news_md-1.0.0/de_core_news_md-1.0.0.tar.gz --no-cache-dir
   - if [[ ! -f data/total_word_feature_extractor.dat ]]; then
       wget -P data/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ install:
   - pip install -r requirements.txt
   - python setup.py install
   - pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-1.2.0/en_core_web_sm-1.2.0.tar.gz --no-cache-dir > jnk
+  - python -m spacy link en_core_web_sm en
   - pip install https://github.com/explosion/spacy-models/releases/download/de_core_news_md-1.0.0/de_core_news_md-1.0.0.tar.gz --no-cache-dir > jnk
+  - python -m spacy link de_core_news_md de
   - if [[ ! -f data/total_word_feature_extractor.dat ]]; then
       wget -P data/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat;
     fi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Changed
     to ``{"intent": {"name": "greeting", "confidence": 0.9}, "entities": []}``
 - camel cased MITIE classes (e.g. ``MITIETokenizer`` → ``MitieTokenizer``)
 - model metadata changed, see migration guide
+- updated to spacy 1.7 (breaks existing spacy models!)
 
 Removed
 -------

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
   "keywords": ["python" ],
   "addons": [],
   "scripts": {
-    "postdeploy": "echo '{}' > config.json;mkdir logs;python -m spacy.en.download all"
+    "postdeploy": "echo '{}' > config.json;mkdir logs;python -m spacy download en"
   },
   "buildpacks": [
     {
@@ -18,8 +18,8 @@
       "generator": "secret",
       "description": "token for validating requests"
     },
-    "RASA_BACKEND": {
-      "description": "which backend to use",
+    "RASA_PIPELINE": {
+      "description": "which pipeline to use",
       "value": "spacy_sklearn"
     },
     "RASA_PATH": {

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -6,6 +6,8 @@ how you can migrate from one version to another.
 0.7.x to master
 ---------------
 
+- Due to the update of spacy to 1.7 (and them breaking backwards compatibility), spacy models need to be retrained.
+
 - The parameter and configuration value name of ``backend`` changed to ``pipeline``.
 
 - There have been changes to the model metadata format. You can either retrain your models or change the stored

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ gevent==1.2.1
 flask==0.12
 boto3==1.4.4
 git+https://github.com/mit-nlp/MITIE.git#egg=mitie
-spacy==1.6.0
+spacy==1.7.2
 scikit-learn==0.18.1
 pytest-pep8==1.0.6
 pytest-xdist==1.15.0


### PR DESCRIPTION
Update spacy backend to 1.7. Breaks model backwards compatibility (i.e. all models using anything from spacy need to be retrained) 