### PR TITLE
Python23support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy=0.19.0 numpy=1.12.1 scikit-learn=0.18.1
+  - conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION scipy=0.19.0 numpy=1.12.1 scikit-learn=0.18.1
   - source activate test-environment
   - pip install -r requirements.txt
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -28,7 +27,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy scikit-learn
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy=0.19.0 numpy=1.12.1 scikit-learn=0.18.1
   - source activate test-environment
   - pip install -r requirements.txt
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ cache:
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 install:
@@ -27,7 +26,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION scipy=0.19.0 numpy=1.12.1 scikit-learn=0.18.1
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy=0.19.0 numpy=1.12.1 scikit-learn=0.18.1
   - source activate test-environment
   - pip install -r requirements.txt
   - python setup.py install

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Changed
 - camel cased MITIE classes (e.g. ``MITIETokenizer`` → ``MitieTokenizer``)
 - model metadata changed, see migration guide
 - updated to spacy 1.7 (breaks existing spacy models!)
+- introduced compatibility with both Python 2 and 3
 
 Removed
 -------

--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import logging
 import pytest
 import spacy

--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import logging
 import pytest
 import spacy

--- a/_pytest/test_components.py
+++ b/_pytest/test_components.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import pytest
 
 from rasa_nlu import config

--- a/_pytest/test_components.py
+++ b/_pytest/test_components.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest
 
 from rasa_nlu import config
@@ -14,7 +15,7 @@ def test_component_init_without_args(component_class):
 
 @pytest.mark.parametrize("component_class", registry.component_classes)
 def test_no_components_with_same_name(component_class):
-    names = map(lambda cls: cls.name, registry.component_classes)
+    names = [cls.name for cls in registry.component_classes]
     assert names.count(component_class.name) == 1, \
         "There is more than one component named {}".format(component_class.name)
 

--- a/_pytest/test_config.py
+++ b/_pytest/test_config.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import tempfile
 import json
 import os

--- a/_pytest/test_config.py
+++ b/_pytest/test_config.py
@@ -1,11 +1,13 @@
+from __future__ import unicode_literals
 import tempfile
-
-from rasa_nlu.config import RasaNLUConfig
 import json
 import os
+import io
+
+from rasa_nlu.config import RasaNLUConfig
 
 
-with open("config_defaults.json", "r") as f:
+with io.open("config_defaults.json", "r") as f:
     defaults = json.load(f)
     # Special treatment for these two, as they are absolute directories
     defaults["path"] = os.path.join(os.getcwd(), defaults["path"])
@@ -14,25 +16,25 @@ with open("config_defaults.json", "r") as f:
 
 def test_default_config():
     final_config = RasaNLUConfig()
-    assert dict(final_config.items()) == defaults
+    assert dict(list(final_config.items())) == defaults
 
 
 def test_blank_config():
     file_config = {}
     cmdline_args = {}
     env_vars = {}
-    with tempfile.NamedTemporaryFile(suffix="_tmp_config_file.json") as f:
+    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json") as f:
         f.write(json.dumps(file_config))
         f.flush()
         final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
-        assert dict(final_config.items()) == defaults
+        assert dict(list(final_config.items())) == defaults
 
 
 def test_file_config_unchanged():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {}
     env_vars = {}
-    with tempfile.NamedTemporaryFile(suffix="_tmp_config_file.json") as f:
+    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json") as f:
         f.write(json.dumps(file_config))
         f.flush()
         final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
@@ -43,7 +45,7 @@ def test_cmdline_overrides_init():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {"path": "/alternate/path"}
     env_vars = {}
-    with tempfile.NamedTemporaryFile(suffix="_tmp_config_file.json") as f:
+    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json") as f:
         f.write(json.dumps(file_config))
         f.flush()
         final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
@@ -54,7 +56,7 @@ def test_envvar_overrides_init():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {}
     env_vars = {"RASA_PATH": "/alternate/path"}
-    with tempfile.NamedTemporaryFile(suffix="_tmp_config_file.json") as f:
+    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json") as f:
         f.write(json.dumps(file_config))
         f.flush()
         final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
@@ -65,7 +67,7 @@ def test_cmdline_overrides_envvar():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {"path": "/another/path"}
     env_vars = {"RASA_PATH": "/alternate/path"}
-    with tempfile.NamedTemporaryFile(suffix="_tmp_config_file.json") as f:
+    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json") as f:
         f.write(json.dumps(file_config))
         f.flush()
         final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)

--- a/_pytest/test_config.py
+++ b/_pytest/test_config.py
@@ -23,7 +23,7 @@ with io.open(CONFIG_DEFAULTS_PATH, "r") as f:
 
 def test_default_config():
     final_config = RasaNLUConfig(CONFIG_DEFAULTS_PATH)
-    assert dict(final_config.items()) == defaults
+    assert dict(list(final_config.items())) == defaults
 
 
 def test_blank_config():
@@ -41,7 +41,7 @@ def test_invalid_config_json():
     file_config = """{"pipeline": [mitie]}"""   # invalid json
     cmdline_args = {}
     env_vars = {}
-    with tempfile.NamedTemporaryFile(suffix="_tmp_config_file.json") as f:
+    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json") as f:
         f.write(file_config)
         f.flush()
         with pytest.raises(rasa_nlu.config.InvalidConfigError):

--- a/_pytest/test_emulators.py
+++ b/_pytest/test_emulators.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 
 def test_luis_request():

--- a/_pytest/test_emulators.py
+++ b/_pytest/test_emulators.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+
 def test_luis_request():
     from rasa_nlu.emulators.luis import LUISEmulator
     em = LUISEmulator()

--- a/_pytest/test_featurizers.py
+++ b/_pytest/test_featurizers.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 
 import numpy as np

--- a/_pytest/test_featurizers.py
+++ b/_pytest/test_featurizers.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import os
 
 import numpy as np

--- a/_pytest/test_interpreter.py
+++ b/_pytest/test_interpreter.py
@@ -1,10 +1,13 @@
+from __future__ import unicode_literals
 import pytest
 
 import utilities
+from utilities import slowtest
 from rasa_nlu import registry
 
 
-@pytest.mark.parametrize("pipeline_template", registry.registered_pipeline_templates.keys())
+@slowtest
+@pytest.mark.parametrize("pipeline_template", list(registry.registered_pipeline_templates.keys()))
 def test_samples(pipeline_template, interpreter_builder):
     interpreter = utilities.interpreter_for(interpreter_builder, utilities.base_test_conf(pipeline_template))
     available_intents = ["greet", "restaurant_search", "affirm", "goodbye", "None"]

--- a/_pytest/test_interpreter.py
+++ b/_pytest/test_interpreter.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import pytest
 
 import utilities

--- a/_pytest/test_multitenancy.py
+++ b/_pytest/test_multitenancy.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import json
 import os
 import tempfile

--- a/_pytest/test_multitenancy.py
+++ b/_pytest/test_multitenancy.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import json
 import os
 import tempfile

--- a/_pytest/test_server.py
+++ b/_pytest/test_server.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import tempfile
 
 import pytest

--- a/_pytest/test_server.py
+++ b/_pytest/test_server.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import tempfile
 
 import pytest
 
 from rasa_nlu.config import RasaNLUConfig
 import json
-import codecs
+import io
 
 from utilities import ResponseTest
 from rasa_nlu.server import create_app
@@ -31,7 +32,7 @@ def app():
 
 def test_root(client):
     response = client.get("/")
-    assert response.status_code == 200 and response.data == "hello"
+    assert response.status_code == 200 and response.data == b"hello"
 
 
 def test_status(client):
@@ -79,8 +80,8 @@ def test_post_parse(client, response_test):
 
 
 def test_post_train(client):
-    with codecs.open('data/examples/luis/demo-restaurants.json',
-                     encoding='utf-8') as train_file:
+    with io.open('data/examples/luis/demo-restaurants.json',
+                 encoding='utf-8') as train_file:
         train_data = json.loads(train_file.read())
     response = client.post("/train", data=json.dumps(train_data), content_type='application/json')
     assert response.status_code == 200

--- a/_pytest/test_synonyms.py
+++ b/_pytest/test_synonyms.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from rasa_nlu.extractors.entity_synonyms import EntitySynonymMapper
 
 

--- a/_pytest/test_synonyms.py
+++ b/_pytest/test_synonyms.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from rasa_nlu.extractors.entity_synonyms import EntitySynonymMapper
 
 

--- a/_pytest/test_tokenizers.py
+++ b/_pytest/test_tokenizers.py
@@ -2,6 +2,9 @@
 
 
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 
 def test_whitespace():

--- a/_pytest/test_tokenizers.py
+++ b/_pytest/test_tokenizers.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import unicode_literals
+
+
 def test_whitespace():
     from rasa_nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
     tk = WhitespaceTokenizer()
@@ -25,5 +28,6 @@ def test_mitie():
     assert tk.tokenize(u"Hi. My name is rasa") == [u'Hi', u'My', u'name', u'is', u'rasa']
     assert tk.tokenize(u"ὦ ἄνδρες ᾿Αθηναῖοι") == [u'ὦ', u'ἄνδρες', u'᾿Αθηναῖοι']
     assert tk.tokenize_with_offsets(u"Forecast for lunch") == ([u'Forecast', u'for', u'lunch'], [0, 9, 13])
-    assert tk.tokenize_with_offsets(u"hey ńöñàśçií how're you?") == ([u'hey', u'ńöñàśçií', u'how', u'\'re', 'you', '?'],
-                                                                            [0, 4, 13, 16, 20, 23])
+    assert tk.tokenize_with_offsets(u"hey ńöñàśçií how're you?") == (
+        [u'hey', u'ńöñàśçií', u'how', u'\'re', 'you', '?'],
+        [0, 4, 13, 16, 20, 23])

--- a/_pytest/test_train.py
+++ b/_pytest/test_train.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import pytest
 
 import utilities

--- a/_pytest/test_train.py
+++ b/_pytest/test_train.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import pytest
 
 import utilities
+from utilities import slowtest
 from rasa_nlu import registry
 
 
-@pytest.mark.parametrize("pipeline_template", registry.registered_pipeline_templates.keys())
+@slowtest
+@pytest.mark.parametrize("pipeline_template", list(registry.registered_pipeline_templates.keys()))
 def test_train_model(pipeline_template, interpreter_builder):
     _config = utilities.base_test_conf(pipeline_template)
     (trained, persisted_path) = utilities.run_train(_config)
@@ -15,7 +18,8 @@ def test_train_model(pipeline_template, interpreter_builder):
     assert loaded.pipeline
 
 
-@pytest.mark.parametrize("pipeline_template", registry.registered_pipeline_templates.keys())
+@slowtest
+@pytest.mark.parametrize("pipeline_template", list(registry.registered_pipeline_templates.keys()))
 def test_train_model_noents(pipeline_template, interpreter_builder):
     _config = utilities.base_test_conf(pipeline_template)
     _config['data'] = "./data/examples/rasa/demo-rasa-noents.json"
@@ -25,7 +29,8 @@ def test_train_model_noents(pipeline_template, interpreter_builder):
     assert loaded.pipeline
 
 
-@pytest.mark.parametrize("pipeline_template", registry.registered_pipeline_templates.keys())
+@slowtest
+@pytest.mark.parametrize("pipeline_template", list(registry.registered_pipeline_templates.keys()))
 def test_train_model_multithread(pipeline_template, interpreter_builder):
     _config = utilities.base_test_conf(pipeline_template)
     _config['num_threads'] = 2
@@ -35,6 +40,7 @@ def test_train_model_multithread(pipeline_template, interpreter_builder):
     assert loaded.pipeline
 
 
+@slowtest
 def test_train_spacy_sklearn_finetune_ner(interpreter_builder):
     _config = utilities.base_test_conf("spacy_sklearn")
     _config['fine_tune_spacy_ner'] = True

--- a/_pytest/test_training_data.py
+++ b/_pytest/test_training_data.py
@@ -41,7 +41,7 @@ def test_rasa_data():
     td = load_data('data/examples/rasa/demo-rasa.json', "en")
     assert td.entity_examples != []
     assert td.intent_examples != []
-    assert len(td.sorted_entity_examples()) >= len(filter(lambda e: e["entities"], td.entity_examples))
+    assert len(td.sorted_entity_examples()) >= len([e for e in td.entity_examples if e["entities"]])
     assert len(td.sorted_intent_examples()) == len(td.intent_examples)
     assert td.entity_synonyms == {}
 

--- a/_pytest/test_training_data.py
+++ b/_pytest/test_training_data.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import tempfile
 
 import pytest

--- a/_pytest/test_training_data.py
+++ b/_pytest/test_training_data.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import tempfile
 
 import pytest

--- a/_pytest/utilities.py
+++ b/_pytest/utilities.py
@@ -1,9 +1,14 @@
+from __future__ import unicode_literals
+from builtins import object
 import tempfile
+import pytest
 
 from rasa_nlu import registry
 from rasa_nlu.config import RasaNLUConfig
 from rasa_nlu.data_router import DataRouter
 from rasa_nlu.train import do_train
+
+slowtest = pytest.mark.slowtest
 
 
 def base_test_conf(pipeline_template):

--- a/_pytest/utilities.py
+++ b/_pytest/utilities.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import object
 import tempfile
 import pytest

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -10,7 +10,19 @@ We created a tag that should get you started quickly if you are searching for
 Python Conventions
 ^^^^^^^^^^^^^^^^^^
 
-Python code should follow the pep-8 spec. 
+Python code should follow the pep-8 spec.
+
+Python 2 and 3 Cross Compatibility
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To ensure cross compatibility between Python 2 and 3 we prioritize Python 3 conventions.
+Keep in mind that:
+
+- all string literals are unicode strings
+- division generates floating point numbers. Use ``//`` for truncated division
+- some built-ins, e.g. ``map`` and ``filter`` return iterators in Python 3. If you want to make use of them import the Python 3 version of them from ``builtins``. Otherwise use list comprehensions, which work uniformly across versions
+- use ``io.open`` instead of the builtin ``open`` when working with files
+
 
 Code of conduct
 ^^^^^^^^^^^^^^^

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -22,6 +22,7 @@ Keep in mind that:
 - division generates floating point numbers. Use ``//`` for truncated division
 - some built-ins, e.g. ``map`` and ``filter`` return iterators in Python 3. If you want to make use of them import the Python 3 version of them from ``builtins``. Otherwise use list comprehensions, which work uniformly across versions
 - use ``io.open`` instead of the builtin ``open`` when working with files
+- The following imports from ``__future__`` are mandatory in every python file: ``unicode_literals``, ``print_function``, ``division``, and ``absolute_import``
 
 
 Code of conduct

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -2,6 +2,8 @@
 
 Using rasa NLU from python
 ==========================
+Apart from running rasa NLU as a HTTP server you can use it directly in your python program.
+Rasa NLU supports both Python 2 and 3.
 
 Training Time
 -------------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -167,6 +167,12 @@ rasa NLU will also print a ``confidence`` value for the intent classification.
 You can use this to do some error handling in your bot (maybe asking the user again if the confidence is low)
 and it's also helpful for prioritising which intents need more training data.
 
+.. note::
+    The output may contain other or less attributes, depending on the pipeline you are using. For
+    example, the ``mitie`` pipeline doesn't include the ``"intent_ranking"`` whereas the ``spacy_sklearn``
+    pipeline does.
+
+
 With very little data, rasa NLU can in certain cases already generalise concepts, for example:
 
 

--- a/rasa_nlu/__init__.py
+++ b/rasa_nlu/__init__.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import rasa_nlu.version
 
 __version__ = version.__version__

--- a/rasa_nlu/__init__.py
+++ b/rasa_nlu/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import rasa_nlu.version
 
 __version__ = version.__version__

--- a/rasa_nlu/classifiers/keyword_intent_classifier.py
+++ b/rasa_nlu/classifiers/keyword_intent_classifier.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+from builtins import map
 from rasa_nlu.components import Component
 
 

--- a/rasa_nlu/classifiers/keyword_intent_classifier.py
+++ b/rasa_nlu/classifiers/keyword_intent_classifier.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import map
 from rasa_nlu.components import Component
 

--- a/rasa_nlu/classifiers/mitie_intent_classifier.py
+++ b/rasa_nlu/classifiers/mitie_intent_classifier.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import os
 
 from typing import Optional

--- a/rasa_nlu/classifiers/mitie_intent_classifier.py
+++ b/rasa_nlu/classifiers/mitie_intent_classifier.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 
 from typing import Optional

--- a/rasa_nlu/classifiers/sklearn_intent_classifier.py
+++ b/rasa_nlu/classifiers/sklearn_intent_classifier.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+from builtins import str
 from builtins import zip
 import os
 import io
@@ -67,7 +68,7 @@ class SklearnIntentClassifier(Component):
         y = self.transform_labels_str2num(labels)
         X = intent_features
 
-        tuned_parameters = [{'C': [1, 2, 5, 10, 20, 100], 'kernel': [str('linear')]}]
+        tuned_parameters = [{'C': [1, 2, 5, 10, 20, 100], 'kernel': ['linear']}]
         cv_splits = min(5, np.min(np.bincount(y)))
         self.clf = GridSearchCV(SVC(C=1, probability=True),
                                 param_grid=tuned_parameters, n_jobs=num_threads,

--- a/rasa_nlu/classifiers/sklearn_intent_classifier.py
+++ b/rasa_nlu/classifiers/sklearn_intent_classifier.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import str
 from builtins import zip
 import os
 import io

--- a/rasa_nlu/classifiers/sklearn_intent_classifier.py
+++ b/rasa_nlu/classifiers/sklearn_intent_classifier.py
@@ -67,7 +67,8 @@ class SklearnIntentClassifier(Component):
         y = self.transform_labels_str2num(labels)
         X = intent_features
 
-        tuned_parameters = [{'C': [1, 2, 5, 10, 20, 100], 'kernel': [str('linear')]}] # dirty str fix because sklearn is expecting str not instance of basestr...
+        # dirty str fix because sklearn is expecting str not instance of basestr...
+        tuned_parameters = [{'C': [1, 2, 5, 10, 20, 100], 'kernel': [str('linear')]}]
         cv_splits = min(5, np.min(np.bincount(y)))
         self.clf = GridSearchCV(SVC(C=1, probability=True),
                                 param_grid=tuned_parameters, n_jobs=num_threads,

--- a/rasa_nlu/classifiers/sklearn_intent_classifier.py
+++ b/rasa_nlu/classifiers/sklearn_intent_classifier.py
@@ -67,7 +67,7 @@ class SklearnIntentClassifier(Component):
         y = self.transform_labels_str2num(labels)
         X = intent_features
 
-        tuned_parameters = [{'C': [1, 2, 5, 10, 20, 100], 'kernel': ['linear']}]
+        tuned_parameters = [{'C': [1, 2, 5, 10, 20, 100], 'kernel': [str('linear')]}] # dirty str fix because sklearn is expecting str not instance of basestr...
         cv_splits = min(5, np.min(np.bincount(y)))
         self.clf = GridSearchCV(SVC(C=1, probability=True),
                                 param_grid=tuned_parameters, n_jobs=num_threads,

--- a/rasa_nlu/classifiers/sklearn_intent_classifier.py
+++ b/rasa_nlu/classifiers/sklearn_intent_classifier.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import zip
 import os
 import io

--- a/rasa_nlu/classifiers/sklearn_intent_classifier.py
+++ b/rasa_nlu/classifiers/sklearn_intent_classifier.py
@@ -1,4 +1,8 @@
+from __future__ import unicode_literals
+from builtins import zip
 import os
+import io
+from future.utils import PY3
 
 from rasa_nlu.components import Component
 from rasa_nlu.training_data import TrainingData
@@ -60,7 +64,7 @@ class SklearnIntentClassifier(Component):
         y = self.transform_labels_str2num(labels)
         X = intent_features
 
-        tuned_parameters = [{'C': [1, 2, 5, 10, 20, 100], 'kernel': ['linear']}]
+        tuned_parameters = [{'C': [1, 2, 5, 10, 20, 100], 'kernel': [str('linear')]}]
         cv_splits = min(5, np.min(np.bincount(y)))
         self.clf = GridSearchCV(SVC(C=1, probability=True),
                                 param_grid=tuned_parameters, n_jobs=num_threads,
@@ -78,7 +82,7 @@ class SklearnIntentClassifier(Component):
         # `predict` returns a matrix as it is supposed to work for multiple examples as well, hence we need to flatten
         intents, probabilities = intents.flatten(), probabilities.flatten()
         if intents.size > 0 and probabilities.size > 0:
-            ranking = zip(list(intents), list(probabilities))[:INTENT_RANKING_LENGTH]
+            ranking = list(zip(list(intents), list(probabilities)))[:INTENT_RANKING_LENGTH]
             return {
                 "intent": {
                     "name": intents[0],
@@ -120,8 +124,11 @@ class SklearnIntentClassifier(Component):
 
         if model_dir and intent_classifier:
             classifier_file = os.path.join(model_dir, intent_classifier)
-            with open(classifier_file, 'rb') as f:
-                return cloudpickle.load(f)
+            with io.open(classifier_file, 'rb') as f:
+                if PY3:
+                    return cloudpickle.load(f, encoding="latin-1")
+                else:
+                    return cloudpickle.load(f)
         else:
             return SklearnIntentClassifier()
 
@@ -132,7 +139,7 @@ class SklearnIntentClassifier(Component):
         import cloudpickle
 
         classifier_file = os.path.join(model_dir, "intent_classifier.pkl")
-        with open(classifier_file, 'wb') as f:
+        with io.open(classifier_file, 'wb') as f:
             cloudpickle.dump(self, f)
 
         return {

--- a/rasa_nlu/components.py
+++ b/rasa_nlu/components.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+from builtins import object
 import inspect
 
 from typing import Optional
@@ -142,20 +144,20 @@ class Component(object):
 
     def pipeline_init_args(self):
         # type: () -> [str]
-        return filter(lambda arg: arg not in ["self"], inspect.getargspec(self.pipeline_init).args)
+        return [arg for arg in inspect.getargspec(self.pipeline_init).args if arg not in ["self"]]
 
     def train_args(self):
         # type: () -> [str]
-        return filter(lambda arg: arg not in ["self"], inspect.getargspec(self.train).args)
+        return [arg for arg in inspect.getargspec(self.train).args if arg not in ["self"]]
 
     def process_args(self):
         # type: () -> [str]
-        return filter(lambda arg: arg not in ["self"], inspect.getargspec(self.process).args)
+        return [arg for arg in inspect.getargspec(self.process).args if arg not in ["self"]]
 
     @classmethod
     def load_args(cls):
         # type: () -> [str]
-        return filter(lambda arg: arg not in ["cls"], inspect.getargspec(cls.load).args)
+        return [arg for arg in inspect.getargspec(cls.load).args if arg not in ["cls"]]
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__

--- a/rasa_nlu/components.py
+++ b/rasa_nlu/components.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import object
 import inspect
 

--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -75,7 +75,7 @@ class RasaNLUConfig(object):
                 warnings.warn("No pipeline specified and unknown pipeline template " +
                               "'{}' passed.".format(self.__dict__['pipeline']))
 
-        for key, value in list(self.items()):
+        for key, value in self.items():
             setattr(self, key, value)
 
     def __getitem__(self, key):
@@ -100,7 +100,7 @@ class RasaNLUConfig(object):
         return json.dumps(self.__dict__, indent=4)
 
     def format_env_vars(self, env_vars):
-        keys = [key for key in list(env_vars.keys()) if "RASA" in key]
+        keys = [key for key in env_vars.keys() if "RASA" in key]
         return {key.split('RASA_')[1].lower(): env_vars[key] for key in keys}
 
     def is_set(self, key):

--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -1,4 +1,6 @@
-import codecs
+from __future__ import unicode_literals
+from builtins import object
+import io
 import json
 import os
 import warnings
@@ -39,7 +41,7 @@ class RasaNLUConfig(object):
 
         self.override(DEFAULT_CONFIG)
         if filename is not None:
-            with codecs.open(filename, encoding='utf-8') as f:
+            with io.open(filename, encoding='utf-8') as f:
                 file_config = json.loads(f.read())
             self.override(file_config)
 
@@ -48,7 +50,7 @@ class RasaNLUConfig(object):
             self.override(env_config)
 
         if cmdline_args is not None:
-            cmdline_config = {k: v for k, v in cmdline_args.items() if v is not None}
+            cmdline_config = {k: v for k, v in list(cmdline_args.items()) if v is not None}
             self.override(cmdline_config)
 
         if isinstance(self.__dict__['pipeline'], six.string_types):
@@ -59,7 +61,7 @@ class RasaNLUConfig(object):
                 warnings.warn("No pipeline specified and unknown pipeline template " +
                               "'{}' passed.".format(self.__dict__['pipeline']))
 
-        for key, value in self.items():
+        for key, value in list(self.items()):
             setattr(self, key, value)
 
     def __getitem__(self, key):
@@ -78,13 +80,13 @@ class RasaNLUConfig(object):
         return len(self.__dict__)
 
     def items(self):
-        return self.__dict__.items()
+        return list(self.__dict__.items())
 
     def view(self):
         return json.dumps(self.__dict__, indent=4)
 
     def format_env_vars(self, env_vars):
-        keys = [key for key in env_vars.keys() if "RASA" in key]
+        keys = [key for key in list(env_vars.keys()) if "RASA" in key]
         return {key.split('RASA_')[1].lower(): env_vars[key] for key in keys}
 
     def is_set(self, key):

--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import object
 import io
 import json

--- a/rasa_nlu/convert.py
+++ b/rasa_nlu/convert.py
@@ -1,5 +1,6 @@
+from __future__ import unicode_literals
 import argparse
-import codecs
+import io
 
 from rasa_nlu.converters import load_data
 
@@ -17,7 +18,7 @@ def create_argparser():
 
 
 def write_file(td, out_file):
-    with codecs.open(out_file, "w") as f:
+    with io.open(out_file, "w") as f:
         f.write(td.as_json(indent=2))
 
 if __name__ == "__main__":

--- a/rasa_nlu/convert.py
+++ b/rasa_nlu/convert.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import argparse
 import io
 

--- a/rasa_nlu/converters.py
+++ b/rasa_nlu/converters.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import io
 import json
 import re

--- a/rasa_nlu/converters.py
+++ b/rasa_nlu/converters.py
@@ -1,4 +1,5 @@
-import codecs
+from __future__ import unicode_literals
+import io
 import json
 import re
 import warnings
@@ -26,16 +27,16 @@ def load_api_data(files):
     common_examples = []
     entity_synonyms = {}
     for filename in files:
-        with codecs.open(filename, encoding="utf-8-sig") as f:
+        with io.open(filename, encoding="utf-8-sig") as f:
             data = json.loads(f.read())
         # get only intents, skip the rest. The property name is the target class
         if "userSays" in data:
             intent = data.get("name")
             for s in data["userSays"]:
-                text = "".join(map(lambda chunk: chunk["text"], s.get("data")))
+                text = "".join([chunk["text"] for chunk in s.get("data")])
                 # add entities to each token, if available
                 entities = []
-                for e in filter(lambda chunk: "alias" in chunk or "meta" in chunk, s.get("data")):
+                for e in [chunk for chunk in s.get("data") if "alias" in chunk or "meta" in chunk]:
                     start = text.find(e["text"])
                     end = start + len(e["text"])
                     val = text[start:end]
@@ -79,7 +80,7 @@ def load_luis_data(filename, tokenizer):
     entity_examples = []
     common_examples = []
 
-    with codecs.open(filename, encoding="utf-8-sig") as f:
+    with io.open(filename, encoding="utf-8-sig") as f:
         data = json.loads(f.read())
     for s in data["utterances"]:
         text = s.get("text")
@@ -112,7 +113,7 @@ def load_wit_data(filename):
     entity_examples = []
     common_examples = []
 
-    with codecs.open(filename, encoding="utf-8-sig") as f:
+    with io.open(filename, encoding="utf-8-sig") as f:
         data = json.loads(f.read())
     for s in data["data"]:
         entities = s.get("entities")
@@ -139,7 +140,7 @@ def load_rasa_data(filename):
     # type: (str) -> TrainingData
     """Loads training data stored in the rasa NLU data format."""
 
-    with codecs.open(filename, encoding="utf-8-sig") as f:
+    with io.open(filename, encoding="utf-8-sig") as f:
         data = json.loads(f.read())
     common = data['rasa_nlu_data'].get("common_examples", list())
     intent = data['rasa_nlu_data'].get("intent_examples", list())
@@ -153,7 +154,7 @@ def guess_format(files):
     """Given a set of files, tries to guess which data format is used."""
 
     for filename in files:
-        with codecs.open(filename, encoding="utf-8-sig") as f:
+        with io.open(filename, encoding="utf-8-sig") as f:
             file_data = json.loads(f.read())
         if "data" in file_data and type(file_data.get("data")) is list:
             return WIT_FILE_FORMAT

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+from builtins import object
 import datetime
 import glob
 import json
@@ -36,7 +38,7 @@ class InterpreterBuilder(object):
     def create_interpreter(self, meta, config):
         context = {"model_dir": meta.model_dir}
 
-        model_config = dict(config.items())
+        model_config = dict(list(config.items()))
         model_config.update(meta.metadata)
 
         pipeline = []
@@ -99,7 +101,7 @@ class DataRouter(object):
 
     def __create_model_store(self):
         # Fallback for users that specified the model path as a string and hence only want a single default model.
-        if type(self.config.server_model_dirs) is unicode or type(self.config.server_model_dirs) is str:
+        if type(self.config.server_model_dirs) is str or type(self.config.server_model_dirs) is str:
             model_dict = {self.DEFAULT_MODEL_NAME: self.config.server_model_dirs}
         elif self.config.server_model_dirs is None:
             model_dict = self.__search_for_models()
@@ -108,7 +110,7 @@ class DataRouter(object):
 
         model_store = {}
 
-        for alias, model_path in model_dict.items():
+        for alias, model_path in list(model_dict.items()):
             try:
                 logging.info("Loading model '{}'...".format(model_path))
                 metadata = DataRouter.read_model_metadata(model_path, self.config)
@@ -189,7 +191,7 @@ class DataRouter(object):
     def get_status(self):
         # This will only count the trainings started from this process, if run in multi worker mode, there might
         # be other trainings run in different processes we don't know about.
-        num_trainings = len(filter(lambda p: p.is_alive(), self.train_procs))
+        num_trainings = len([p for p in self.train_procs if p.is_alive()])
         models = glob.glob(os.path.join(self.model_dir, 'model*'))
         return {
             "trainings_under_this_process": num_trainings,
@@ -198,11 +200,11 @@ class DataRouter(object):
 
     def start_train_process(self, data):
         logging.info("Starting model training")
-        fd, fname = tempfile.mkstemp(suffix="_training_data.json")
-        os.write(fd, data)
-        os.close(fd)
-        _config = dict(self.config.items())
-        _config["data"] = fname
+        f = tempfile.NamedTemporaryFile("w+", suffix="_training_data.json", delete=False)
+        f.write(data)
+        f.close()
+        _config = dict(list(self.config.items()))
+        _config["data"] = f.name
         train_config = RasaNLUConfig(cmdline_args=_config)
         process = multiprocessing.Process(target=do_train, args=(train_config,))
         self.train_procs.append(process)

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import object
 import datetime
 import glob

--- a/rasa_nlu/download.py
+++ b/rasa_nlu/download.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import argparse
 import logging
 import os

--- a/rasa_nlu/download.py
+++ b/rasa_nlu/download.py
@@ -1,7 +1,9 @@
+from __future__ import unicode_literals
 import argparse
 import logging
 import os
 import warnings
+import io
 
 from rasa_nlu.config import RasaNLUConfig
 from tqdm import tqdm
@@ -32,7 +34,7 @@ def download_mitie_fe_file(fe_file):
     logging.info("Downloading from {}".format(_fe_file_url))
     response = requests.get(_fe_file_url, stream=True)
 
-    with open(fe_file, "wb") as output:
+    with io.open(fe_file, "wb") as output:
         for data in tqdm(response.iter_content(chunk_size=1024*1024), unit='MB', unit_scale=True):
             output.write(data)
     logging.debug("file written! {0}, {1}".format(fe_file, os.path.exists(fe_file)))
@@ -48,6 +50,6 @@ def download(config, pkg="mitie"):
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
     parser = create_argparser()
-    cmdline_args = {key: val for key, val in vars(parser.parse_args()).items() if val is not None}
+    cmdline_args = {key: val for key, val in list(vars(parser.parse_args()).items()) if val is not None}
     config = RasaNLUConfig(cmdline_args.get("config"), os.environ, cmdline_args)
     download(config, cmdline_args["package"])

--- a/rasa_nlu/emulators/__init__.py
+++ b/rasa_nlu/emulators/__init__.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from builtins import object
+
+
 class NoEmulator(object):
     def __init__(self):
         self.name = None

--- a/rasa_nlu/emulators/__init__.py
+++ b/rasa_nlu/emulators/__init__.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import object
 
 

--- a/rasa_nlu/emulators/api.py
+++ b/rasa_nlu/emulators/api.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import str
 import uuid
 from datetime import datetime

--- a/rasa_nlu/emulators/api.py
+++ b/rasa_nlu/emulators/api.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+from builtins import str
 import uuid
 from datetime import datetime
 
@@ -11,12 +13,12 @@ class ApiEmulator(NoEmulator):
 
     def normalise_response_json(self, data):
         # populate entities dict
-        entities = {entity_type: [] for entity_type in set(map(lambda x: x["entity"], data["entities"]))}
+        entities = {entity_type: [] for entity_type in set([x["entity"] for x in data["entities"]])}
         for entity in data["entities"]:
             entities[entity["entity"]].append(entity["value"])
 
         return {
-            "id": unicode(uuid.uuid1()),
+            "id": str(uuid.uuid1()),
             "timestamp": datetime.now().isoformat("T"),
             "result": {
                 "source": "agent",
@@ -26,7 +28,7 @@ class ApiEmulator(NoEmulator):
                 "parameters": entities,
                 "contexts": [],
                 "metadata": {
-                    "intentId": unicode(uuid.uuid1()),
+                    "intentId": str(uuid.uuid1()),
                     "webhookUsed": "false",
                     "intentName": data["intent"]
                 },
@@ -37,5 +39,5 @@ class ApiEmulator(NoEmulator):
                 "code": 200,
                 "errorType": "success"
             },
-            "sessionId": unicode(uuid.uuid1())
+            "sessionId": str(uuid.uuid1())
         }

--- a/rasa_nlu/emulators/luis.py
+++ b/rasa_nlu/emulators/luis.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from rasa_nlu.emulators import NoEmulator
 
 

--- a/rasa_nlu/emulators/luis.py
+++ b/rasa_nlu/emulators/luis.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from rasa_nlu.emulators import NoEmulator
 
 

--- a/rasa_nlu/emulators/wit.py
+++ b/rasa_nlu/emulators/wit.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from rasa_nlu.emulators import NoEmulator
 
 

--- a/rasa_nlu/emulators/wit.py
+++ b/rasa_nlu/emulators/wit.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from rasa_nlu.emulators import NoEmulator
 
 

--- a/rasa_nlu/extractors/__init__.py
+++ b/rasa_nlu/extractors/__init__.py
@@ -1,2 +1,6 @@
+from __future__ import unicode_literals
+from builtins import object
+
+
 class EntityExtractor(object):
     pass

--- a/rasa_nlu/extractors/__init__.py
+++ b/rasa_nlu/extractors/__init__.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import object
 
 

--- a/rasa_nlu/extractors/entity_synonyms.py
+++ b/rasa_nlu/extractors/entity_synonyms.py
@@ -1,4 +1,7 @@
-import codecs
+from __future__ import unicode_literals
+from builtins import str
+from builtins import range
+import io
 import json
 import os
 import warnings
@@ -22,7 +25,7 @@ class EntitySynonymMapper(Component):
     def train(self, training_data):
         # type: (TrainingData) -> None
 
-        for key, value in training_data.entity_synonyms.items():
+        for key, value in list(training_data.entity_synonyms.items()):
             self.add_entities_if_synonyms(key, value)
 
         for example in training_data.entity_examples:
@@ -45,7 +48,7 @@ class EntitySynonymMapper(Component):
 
         if self.synonyms:
             entity_synonyms_file = os.path.join(model_dir, "index.json")
-            with open(entity_synonyms_file, 'w') as f:
+            with io.open(entity_synonyms_file, 'w') as f:
                 json.dump(self.synonyms, f)
             return {"entity_synonyms": "index.json"}
         else:
@@ -58,7 +61,7 @@ class EntitySynonymMapper(Component):
         if model_dir and entity_synonyms:
             entity_synonyms_file = os.path.join(model_dir, "index.json")
             if os.path.isfile(entity_synonyms_file):
-                with codecs.open(entity_synonyms_file, encoding='utf-8') as f:
+                with io.open(entity_synonyms_file, encoding='utf-8') as f:
                     synonyms = json.loads(f.read())
                 return EntitySynonymMapper(synonyms)
             else:
@@ -73,8 +76,8 @@ class EntitySynonymMapper(Component):
 
     def add_entities_if_synonyms(self, entity_a, entity_b):
         if entity_b is not None:
-            original = entity_a.lower() if type(entity_a) == unicode else unicode(entity_a)
-            replacement = entity_b.lower() if type(entity_b) == unicode else unicode(entity_b)
+            original = entity_a.lower() if type(entity_a) == str else str(entity_a)
+            replacement = entity_b.lower() if type(entity_b) == str else str(entity_b)
 
             if original != replacement:
                 self.synonyms[original] = replacement

--- a/rasa_nlu/extractors/entity_synonyms.py
+++ b/rasa_nlu/extractors/entity_synonyms.py
@@ -49,7 +49,7 @@ class EntitySynonymMapper(Component):
         if self.synonyms:
             entity_synonyms_file = os.path.join(model_dir, "index.json")
             with io.open(entity_synonyms_file, 'w') as f:
-                json.dump(self.synonyms, f)
+                f.write(str(json.dumps(self.synonyms)))
             return {"entity_synonyms": "index.json"}
         else:
             return {"entity_synonyms": None}

--- a/rasa_nlu/extractors/entity_synonyms.py
+++ b/rasa_nlu/extractors/entity_synonyms.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import str
 from builtins import range
 import io

--- a/rasa_nlu/extractors/mitie_entity_extractor.py
+++ b/rasa_nlu/extractors/mitie_entity_extractor.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+from builtins import range
 import os
 import re
 
@@ -72,7 +74,7 @@ class MitieEntityExtractor(Component, EntityExtractor):
             sample = ner_training_instance(tokens)
             for ent in example["entities"]:
                 start, end = MitieEntityExtractor.find_entity(ent, text)
-                sample.add_entity(xrange(start, end), ent["entity"])
+                sample.add_entity(list(range(start, end)), ent["entity"])
                 found_one_entity = True
 
             trainer.add(sample)

--- a/rasa_nlu/extractors/mitie_entity_extractor.py
+++ b/rasa_nlu/extractors/mitie_entity_extractor.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import range
 import os
 import re

--- a/rasa_nlu/extractors/spacy_entity_extractor.py
+++ b/rasa_nlu/extractors/spacy_entity_extractor.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, print_function
 
-from builtins import range
+from builtins import range, str
 import os
 import random
 import io
@@ -105,7 +105,7 @@ class SpacyEntityExtractor(Component, EntityExtractor):
             entity_extractor_file = os.path.join(ner_dir, "model")
 
             with io.open(entity_extractor_config_file, 'w') as f:
-                json.dump(self.ner.cfg, f)
+                f.write(str(json.dumps(self.ner.cfg)))
             self.ner.model.dump(entity_extractor_file)
             return {
                 "entity_extractor": "ner",

--- a/rasa_nlu/extractors/spacy_entity_extractor.py
+++ b/rasa_nlu/extractors/spacy_entity_extractor.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals, print_function
+from __future__ import division
+from __future__ import absolute_import
 
 from builtins import range, str
 import os

--- a/rasa_nlu/extractors/spacy_entity_extractor.py
+++ b/rasa_nlu/extractors/spacy_entity_extractor.py
@@ -1,7 +1,9 @@
 from __future__ import unicode_literals, print_function
 
+from builtins import range
 import os
 import random
+import io
 
 import pathlib
 import warnings
@@ -102,7 +104,7 @@ class SpacyEntityExtractor(Component, EntityExtractor):
             entity_extractor_config_file = os.path.join(ner_dir, "config.json")
             entity_extractor_file = os.path.join(ner_dir, "model")
 
-            with open(entity_extractor_config_file, 'w') as f:
+            with io.open(entity_extractor_config_file, 'w') as f:
                 json.dump(self.ner.cfg, f)
             self.ner.model.dump(entity_extractor_file)
             return {

--- a/rasa_nlu/featurizers/__init__.py
+++ b/rasa_nlu/featurizers/__init__.py
@@ -1,2 +1,6 @@
+from __future__ import unicode_literals
+from builtins import object
+
+
 class Featurizer(object):
     pass

--- a/rasa_nlu/featurizers/__init__.py
+++ b/rasa_nlu/featurizers/__init__.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import object
 
 

--- a/rasa_nlu/featurizers/mitie_featurizer.py
+++ b/rasa_nlu/featurizers/mitie_featurizer.py
@@ -2,7 +2,6 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from past.utils import old_div
 from rasa_nlu.components import Component
 from rasa_nlu.featurizers import Featurizer
 from rasa_nlu.training_data import TrainingData
@@ -50,7 +49,7 @@ class MitieFeaturizer(Featurizer, Component):
         for token in tokens:
             vec += feature_extractor.get_feature_vector(token)
         if tokens:
-            return old_div(vec, len(tokens))
+            return vec / len(tokens)
         else:
             return vec
 

--- a/rasa_nlu/featurizers/mitie_featurizer.py
+++ b/rasa_nlu/featurizers/mitie_featurizer.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import unicode_literals
+from past.utils import old_div
 from rasa_nlu.components import Component
 from rasa_nlu.featurizers import Featurizer
 from rasa_nlu.training_data import TrainingData
@@ -45,7 +48,7 @@ class MitieFeaturizer(Featurizer, Component):
         for token in tokens:
             vec += feature_extractor.get_feature_vector(token)
         if tokens:
-            return vec / len(tokens)
+            return old_div(vec, len(tokens))
         else:
             return vec
 

--- a/rasa_nlu/featurizers/mitie_featurizer.py
+++ b/rasa_nlu/featurizers/mitie_featurizer.py
@@ -1,5 +1,7 @@
 from __future__ import division
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 from past.utils import old_div
 from rasa_nlu.components import Component
 from rasa_nlu.featurizers import Featurizer

--- a/rasa_nlu/featurizers/ngram_featurizer.py
+++ b/rasa_nlu/featurizers/ngram_featurizer.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import map
 from builtins import range
 import logging

--- a/rasa_nlu/featurizers/ngram_featurizer.py
+++ b/rasa_nlu/featurizers/ngram_featurizer.py
@@ -1,12 +1,17 @@
+from __future__ import unicode_literals
+from builtins import map
+from builtins import range
 import logging
 import os
 import re
 import time
 import warnings
+import io
 from collections import Counter
 from string import punctuation
 import cloudpickle
 from typing import Optional
+from future.utils import PY3
 
 from rasa_nlu.components import Component
 from rasa_nlu.training_data import TrainingData
@@ -68,8 +73,11 @@ class NGramFeaturizer(Component):
 
         if model_dir and featurizer_file:
             classifier_file = os.path.join(model_dir, featurizer_file)
-            with open(classifier_file, 'rb') as f:
-                return cloudpickle.load(f)
+            with io.open(classifier_file, 'rb') as f:
+                if PY3:
+                    return cloudpickle.load(f, encoding="latin-1")
+                else:
+                    return cloudpickle.load(f)
         else:
             return NGramFeaturizer()
 
@@ -78,7 +86,7 @@ class NGramFeaturizer(Component):
         """Persist this model into the passed directory. Returns the metadata necessary to load the model again."""
 
         classifier_file = os.path.join(model_dir, "ngram_featurizer.pkl")
-        with open(classifier_file, 'wb') as f:
+        with io.open(classifier_file, 'wb') as f:
             cloudpickle.dump(self, f)
 
         return {
@@ -179,7 +187,7 @@ class NGramFeaturizer(Component):
 
         cleaned_sentence = self._remove_in_vocab_words_from_sentence(sentence, spacy_nlp)
         presence_vector = np.zeros(len(ngrams))
-        idx_array = [idx for idx in xrange(len(ngrams)) if ngrams[idx] in cleaned_sentence]
+        idx_array = [idx for idx in range(len(ngrams)) if ngrams[idx] in cleaned_sentence]
         presence_vector[idx_array] = 1
         return presence_vector
 
@@ -192,7 +200,7 @@ class NGramFeaturizer(Component):
         features = {}
         counters = {}
 
-        for n in xrange(self.n_gram_min_length, self.n_gram_max_length):
+        for n in range(self.n_gram_min_length, self.n_gram_max_length):
             candidates = []
             features[n] = []
             counters[n] = Counter()
@@ -201,7 +209,7 @@ class NGramFeaturizer(Component):
             for text in list_of_strings:
                 text = text.replace(punctuation, ' ')
                 for word in text.lower().split(' '):
-                    cands = [word[i:i + n] for i in xrange(len(word) - n)]
+                    cands = [word[i:i + n] for i in range(len(word) - n)]
                     for cand in cands:
                         counters[n][cand] += 1
                         if cand not in candidates:
@@ -219,7 +227,7 @@ class NGramFeaturizer(Component):
                         if counters[n - 1][end] == counters[n][can] and end in features[n - 1]:
                             features[n - 1].remove(end)
 
-        return [item for sublist in features.values() for item in sublist]
+        return [item for sublist in list(features.values()) for item in sublist]
 
     def _create_bow_vecs(self, intent_features, sentences, spacy_nlp, max_ngrams=None):
         """Given a set of sentences, returns a feature vector for each sentence.
@@ -255,7 +263,7 @@ class NGramFeaturizer(Component):
         cv_splits = min(10, np.min(np.bincount(y)))
         if cv_splits >= 3:
             logging.debug("Started ngram cross-validation to find best number of ngrams to use...")
-            num_ngrams = np.unique(map(int, np.floor(np.linspace(1, max_ngrams, 8))))
+            num_ngrams = np.unique(list(map(int, np.floor(np.linspace(1, max_ngrams, 8)))))
             no_ngrams_X = self._create_bow_vecs(intent_features, sentences, spacy_nlp, max_ngrams=0)
             no_ngrams_score = np.mean(cross_val_score(clf2, no_ngrams_X, y, cv=cv_splits))
             scores = []

--- a/rasa_nlu/featurizers/spacy_featurizer.py
+++ b/rasa_nlu/featurizers/spacy_featurizer.py
@@ -1,5 +1,7 @@
 from __future__ import division
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 from past.utils import old_div
 from rasa_nlu.featurizers import Featurizer
 from rasa_nlu.components import Component

--- a/rasa_nlu/featurizers/spacy_featurizer.py
+++ b/rasa_nlu/featurizers/spacy_featurizer.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from __future__ import unicode_literals
+from past.utils import old_div
 from rasa_nlu.featurizers import Featurizer
 from rasa_nlu.components import Component
 from rasa_nlu.training_data import TrainingData
@@ -48,7 +51,7 @@ class SpacyFeaturizer(Featurizer, Component):
             if token.has_vector:
                 vec.append(token.vector)
         if vec:
-            return np.sum(vec, axis=0) / len(vec)
+            return old_div(np.sum(vec, axis=0), len(vec))
         else:
             return np.zeros(self.ndim(nlp))
 

--- a/rasa_nlu/featurizers/spacy_featurizer.py
+++ b/rasa_nlu/featurizers/spacy_featurizer.py
@@ -2,7 +2,6 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from past.utils import old_div
 from rasa_nlu.featurizers import Featurizer
 from rasa_nlu.components import Component
 from rasa_nlu.training_data import TrainingData
@@ -53,7 +52,7 @@ class SpacyFeaturizer(Featurizer, Component):
             if token.has_vector:
                 vec.append(token.vector)
         if vec:
-            return old_div(np.sum(vec, axis=0), len(vec))
+            return np.sum(vec, axis=0) / len(vec)
         else:
             return np.zeros(self.ndim(nlp))
 

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import str
 from builtins import object
 import datetime

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -83,7 +83,7 @@ class Metadata(object):
         })
 
         with io.open(os.path.join(model_dir, 'metadata.json'), 'w') as f:
-            f.write(json.dumps(metadata, indent=4))
+            f.write(str(json.dumps(metadata, indent=4)))
 
 
 class Trainer(object):

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -1,7 +1,11 @@
+from __future__ import unicode_literals
+from builtins import str
+from builtins import object
 import datetime
 import json
 import logging
 import os
+import io
 
 from typing import Optional
 
@@ -31,8 +35,8 @@ class Metadata(object):
         # type: (str) -> 'Metadata'
         """Loads the metadata from a models directory."""
 
-        with open(os.path.join(model_dir, 'metadata.json'), 'rb') as f:
-            data = json.loads(f.read().decode('utf-8'))
+        with io.open(os.path.join(model_dir, 'metadata.json'), encoding="utf-8") as f:
+            data = json.loads(f.read())
         return Metadata(data, model_dir)
 
     def __init__(self, metadata, model_dir):
@@ -78,7 +82,7 @@ class Metadata(object):
             "rasa_nlu_version": rasa_nlu.__version__,
         })
 
-        with open(os.path.join(model_dir, 'metadata.json'), 'w') as f:
+        with io.open(os.path.join(model_dir, 'metadata.json'), 'w') as f:
             f.write(json.dumps(metadata, indent=4))
 
 
@@ -216,7 +220,7 @@ class Interpreter(object):
 
         context = {"model_dir": meta.model_dir}
 
-        config = dict(rasa_config.items())
+        config = dict(list(rasa_config.items()))
         config.update(meta.metadata)
 
         pipeline = []
@@ -247,9 +251,6 @@ class Interpreter(object):
         # type: (basestring) -> dict
         """Parse the input text, classify it and return an object containing its intent and entities."""
 
-        if type(text) is str:
-            text = unicode(text, "utf-8")
-
         current_context = self.context.copy()
 
         current_context.update({
@@ -266,7 +267,7 @@ class Interpreter(object):
                 raise Exception("Failed to parse at component '{}'. {}".format(component.name, e.message))
 
         result = self.default_output_attributes.copy()
-        all_attributes = self.default_output_attributes.keys() + self.output_attributes
+        all_attributes = list(self.default_output_attributes.keys()) + self.output_attributes
         # Ensure only keys of `all_attributes` are present and no other keys are returned
         result.update({key: current_context[key] for key in all_attributes if key in current_context})
         return result

--- a/rasa_nlu/persistor.py
+++ b/rasa_nlu/persistor.py
@@ -1,6 +1,9 @@
+from __future__ import unicode_literals
+from builtins import object
 import os
 import shutil
 import tarfile
+import io
 
 import boto3
 import botocore
@@ -36,7 +39,7 @@ class Persistor(object):
         # type: (str) -> None
         """Downloads a model that has previously been persisted to s3."""
 
-        with open(filename, 'wb') as f:
+        with io.open(filename, 'wb') as f:
             self.bucket.download_fileobj(filename, f)
         with tarfile.open(filename, "r:gz") as tar:
             tar.extractall(self.data_dir)

--- a/rasa_nlu/persistor.py
+++ b/rasa_nlu/persistor.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import object
 import os
 import shutil

--- a/rasa_nlu/registry.py
+++ b/rasa_nlu/registry.py
@@ -1,6 +1,7 @@
 """This is a somewhat delicate package. It contains all registered components and preconfigured templates.
 
 Hence, it imports all of the components. To avoid cycles, no component should import this in module scope."""
+from __future__ import unicode_literals
 from typing import Optional
 from typing import Type
 

--- a/rasa_nlu/registry.py
+++ b/rasa_nlu/registry.py
@@ -2,6 +2,9 @@
 
 Hence, it imports all of the components. To avoid cycles, no component should import this in module scope."""
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from typing import Optional
 from typing import Type
 

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import argparse
 import logging
 import os

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import argparse
 import logging
 import os
@@ -96,7 +97,7 @@ def create_app(config):
 if __name__ == '__main__':
     # Running as standalone python application
     arg_parser = create_arg_parser()
-    cmdline_args = {key: val for key, val in vars(arg_parser.parse_args()).items() if val is not None}
+    cmdline_args = {key: val for key, val in list(vars(arg_parser.parse_args()).items()) if val is not None}
     rasa_nlu_config = RasaNLUConfig(cmdline_args.get("config"), os.environ, cmdline_args)
     app = WSGIServer(('0.0.0.0', rasa_nlu_config['port']), create_app(rasa_nlu_config))
     logging.info('Started http server on port %s' % rasa_nlu_config['port'])

--- a/rasa_nlu/tokenizers/__init__.py
+++ b/rasa_nlu/tokenizers/__init__.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from builtins import object
+
+
 def tokenizer_from_name(name, language):
     from rasa_nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
     from rasa_nlu.tokenizers.mitie_tokenizer import MitieTokenizer

--- a/rasa_nlu/tokenizers/__init__.py
+++ b/rasa_nlu/tokenizers/__init__.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import object
 
 

--- a/rasa_nlu/tokenizers/mitie_tokenizer.py
+++ b/rasa_nlu/tokenizers/mitie_tokenizer.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import str
 import re
 

--- a/rasa_nlu/tokenizers/mitie_tokenizer.py
+++ b/rasa_nlu/tokenizers/mitie_tokenizer.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+from builtins import str
 import re
 
 from rasa_nlu.tokenizers import Tokenizer

--- a/rasa_nlu/tokenizers/spacy_tokenizer.py
+++ b/rasa_nlu/tokenizers/spacy_tokenizer.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from rasa_nlu.tokenizers import Tokenizer
 from rasa_nlu.components import Component
 

--- a/rasa_nlu/tokenizers/spacy_tokenizer.py
+++ b/rasa_nlu/tokenizers/spacy_tokenizer.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from rasa_nlu.tokenizers import Tokenizer
 from rasa_nlu.components import Component
 

--- a/rasa_nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa_nlu/tokenizers/whitespace_tokenizer.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from rasa_nlu.tokenizers import Tokenizer
 from rasa_nlu.components import Component
 

--- a/rasa_nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa_nlu/tokenizers/whitespace_tokenizer.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from rasa_nlu.tokenizers import Tokenizer
 from rasa_nlu.components import Component
 

--- a/rasa_nlu/train.py
+++ b/rasa_nlu/train.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import argparse
 import logging
 import os

--- a/rasa_nlu/train.py
+++ b/rasa_nlu/train.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import argparse
 import logging
 import os

--- a/rasa_nlu/training_data.py
+++ b/rasa_nlu/training_data.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import object, str
 import json
 import os

--- a/rasa_nlu/training_data.py
+++ b/rasa_nlu/training_data.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from builtins import object
+from builtins import object, str
 import json
 import os
 import warnings
@@ -47,13 +47,13 @@ class TrainingData(object):
         # type: (dict) -> str
         """Represent this set of training examples as json adding the passed meta information."""
 
-        return json.dumps({
+        return str(json.dumps({
             "rasa_nlu_data": {
                 "common_examples": self.common_examples,
                 "intent_examples": self.intent_examples_only,
                 "entity_examples": self.entity_examples_only,
             }
-        }, **kwargs)
+        }, **kwargs))
 
     def persist(self, dir_name):
         # type: (str) -> dict

--- a/rasa_nlu/training_data.py
+++ b/rasa_nlu/training_data.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import object, str
+from builtins import object, str, filter
 import json
 import os
 import warnings
@@ -33,11 +33,13 @@ class TrainingData(object):
 
     @property
     def intent_examples(self):
-        return filter(lambda e: "intent" in e, self.intent_examples_only + self.common_examples)
+        return list(filter(lambda e: "intent" in e,
+                           self.intent_examples_only + self.common_examples))
 
     @property
     def entity_examples(self):
-        return filter(lambda e: "entities" in e, self.entity_examples_only + self.common_examples)
+        return list(filter(lambda e: "entities" in e,
+                           self.entity_examples_only + self.common_examples))
 
     @property
     def num_entity_examples(self):

--- a/rasa_nlu/training_data.py
+++ b/rasa_nlu/training_data.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+from builtins import object
 import json
 import os
 import warnings
 from itertools import groupby
+import io
 
 
 class TrainingData(object):
@@ -54,10 +57,10 @@ class TrainingData(object):
 
     def persist(self, dir_name):
         # type: (str) -> dict
-        """Persists this training data to disk and returnes necessary information to load it again."""
+        """Persists this training data to disk and returns necessary information to load it again."""
 
         data_file = os.path.join(dir_name, "training_data.json")
-        with open(data_file, 'w') as f:
+        with io.open(data_file, 'w') as f:
             f.write(self.as_json(indent=2))
 
         return {

--- a/rasa_nlu/utils/__init__.py
+++ b/rasa_nlu/utils/__init__.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import os
 
 from typing import Optional

--- a/rasa_nlu/utils/__init__.py
+++ b/rasa_nlu/utils/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 
 from typing import Optional
@@ -40,7 +41,7 @@ def recursively_find_files(resource_name):
         nodes_to_visit = [resource_name]
         while len(nodes_to_visit) > 0:
             # skip hidden files
-            nodes_to_visit = filter(lambda f: not f.split("/")[-1].startswith('.'), nodes_to_visit)
+            nodes_to_visit = [f for f in nodes_to_visit if not f.split("/")[-1].startswith('.')]
 
             current_node = nodes_to_visit[0]
             # if current node is a folder, schedule its children for a visit. Else add them to the resources.

--- a/rasa_nlu/utils/mitie_utils.py
+++ b/rasa_nlu/utils/mitie_utils.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from builtins import str
 from mitie import total_word_feature_extractor
 from typing import Optional

--- a/rasa_nlu/utils/mitie_utils.py
+++ b/rasa_nlu/utils/mitie_utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+from builtins import str
 from mitie import total_word_feature_extractor
 from typing import Optional
 

--- a/rasa_nlu/utils/spacy_utils.py
+++ b/rasa_nlu/utils/spacy_utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from typing import Optional
 
 from rasa_nlu.components import Component

--- a/rasa_nlu/utils/spacy_utils.py
+++ b/rasa_nlu/utils/spacy_utils.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from typing import Optional
 
 from rasa_nlu.components import Component

--- a/rasa_nlu/version.py
+++ b/rasa_nlu/version.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = '0.8.0a3'
+__version__ = '0.8.0a4'

--- a/rasa_nlu/version.py
+++ b/rasa_nlu/version.py
@@ -1,1 +1,2 @@
+from __future__ import unicode_literals
 __version__ = '0.8.0a1'

--- a/rasa_nlu/version.py
+++ b/rasa_nlu/version.py
@@ -1,2 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 __version__ = '0.8.0a1'

--- a/rasa_nlu/wsgi.py
+++ b/rasa_nlu/wsgi.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 
 import logging

--- a/rasa_nlu/wsgi.py
+++ b/rasa_nlu/wsgi.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import os
 
 import logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ pytest-flask==0.10.0
 scipy==0.19.0
 pytest==3.0.7
 typing==3.5.3.0
+future==0.16.0
+six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,13 @@ setup(
         'rasa_nlu.featurizers',
         'rasa_nlu.tokenizers',
     ],
+    classifiers=[
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6"
+    ],
     version=__version__,
     install_requires=install_requires,
     tests_require=tests_requires,

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
     ],
     classifiers=[
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6"


### PR DESCRIPTION
Made the codebase python 2 and 3 compatible (Fixes #68 ) . I prioritized the python 3 convention in case of differences and added the following to the documentation:

```
To ensure cross compatibility between Python 2 and 3 we prioritize Python 3 conventions.
Keep in mind that:

- all string literals are unicode strings
- division generates floating point numbers. Use ``//`` for truncated division
- some built-ins, e.g. ``map`` and ``filter`` return iterators in Python 3. 
  If you want to make use of them import the Python 3 version of them from ``builtins``. 
  Otherwise use list comprehensions, which work uniformly across versions
- use ``io.open`` instead of the builtin ``open`` when working with files
```

