### PR TITLE
Fail if pipeline is empty

### DIFF
--- a/_pytest/test_train.py
+++ b/_pytest/test_train.py
@@ -43,6 +43,12 @@ def test_train_model_multithread(pipeline_template, interpreter_builder):
     assert loaded.pipeline
 
 
+def test_train_model_empty_pipeline():
+    _config = utilities.base_test_conf(pipeline_template=None)   # Should return an empty pipeline
+    with pytest.raises(ValueError):
+        utilities.run_train(_config)
+
+
 @slowtest
 def test_train_spacy_sklearn_finetune_ner(interpreter_builder):
     _config = utilities.base_test_conf("spacy_sklearn")

--- a/_pytest/utilities.py
+++ b/_pytest/utilities.py
@@ -18,7 +18,7 @@ def base_test_conf(pipeline_template):
     return RasaNLUConfig(cmdline_args={
         'response_log': temp_log_file_dir(),
         'port': 5022,
-        "pipeline": registry.registered_pipeline_templates[pipeline_template],
+        "pipeline": registry.registered_pipeline_templates.get(pipeline_template),
         "path": tempfile.mkdtemp(),
         "data": "./data/examples/rasa/demo-rasa.json"
     })

--- a/_pytest/utilities.py
+++ b/_pytest/utilities.py
@@ -18,7 +18,7 @@ def base_test_conf(pipeline_template):
     return RasaNLUConfig(cmdline_args={
         'response_log': temp_log_file_dir(),
         'port': 5022,
-        "pipeline": registry.registered_pipeline_templates.get(pipeline_template),
+        "pipeline": registry.registered_pipeline_templates.get(pipeline_template, []),
         "path": tempfile.mkdtemp(),
         "data": "./data/examples/rasa/demo-rasa.json"
     })

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -110,9 +110,15 @@ class Trainer(object):
             else:
                 raise Exception("Unregistered component '{}'. Failed to start trainer.".format(component_name))
 
-    def validate(self):
+    def validate(self, allow_empty_pipeline=False):
         # type: () -> None
         """Validates a pipeline before it is run. Ensures, that all arguments are present to train the pipeline."""
+
+        # Ensure the pipeline is not empty
+        if not allow_empty_pipeline and len(self.pipeline) == 0:
+            raise Exception("Can not train an empty pipeline. " +
+                            "Make sure to specify a proper pipeline in the configuration using the `pipeline` key." +
+                            "The `backend` configuration key is NOT supported anymore.")
 
         # Validate the init phase
         context = {}

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -116,9 +116,9 @@ class Trainer(object):
 
         # Ensure the pipeline is not empty
         if not allow_empty_pipeline and len(self.pipeline) == 0:
-            raise Exception("Can not train an empty pipeline. " +
-                            "Make sure to specify a proper pipeline in the configuration using the `pipeline` key." +
-                            "The `backend` configuration key is NOT supported anymore.")
+            raise ValueError("Can not train an empty pipeline. " +
+                             "Make sure to specify a proper pipeline in the configuration using the `pipeline` key." +
+                             "The `backend` configuration key is NOT supported anymore.")
 
         # Validate the init phase
         context = {}


### PR DESCRIPTION
Throws an exception if the user created a configuration that results in an empty pipeline, i.e. no components are in there. (e.g. happens if the user uses a configuration from 0.7 without a proper migration to 0.8)