### PR TITLE
Training data validation using json schema

### DIFF
--- a/rasa_nlu/converters.py
+++ b/rasa_nlu/converters.py
@@ -139,12 +139,77 @@ def load_wit_data(filename):
     return TrainingData(intent_examples, entity_examples, common_examples)
 
 
+def rasa_nlu_data_schema():
+    training_example_schema = {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string"},
+            "intent": {"type": "string"},
+            "entities": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "start": {"type": "number"},
+                        "end": {"type": "number"},
+                        "value": {"type": "string"},
+                        "entity": {"type": "string"}
+                    },
+                    "required": ["start", "end", "entity"]
+                }
+            }
+        },
+        "required": ["text"]
+    }
+
+    return {
+        "type": "object",
+        "properties": {
+            "rasa_nlu_data": {
+                "type": "object",
+                "properties": {
+                    "common_examples": {
+                        "type": "array",
+                        "items": training_example_schema
+                    },
+                    "intent_examples": {
+                        "type": "array",
+                        "items": training_example_schema
+                    },
+                    "entity_examples": {
+                        "type": "array",
+                        "items": training_example_schema
+                    }
+                }
+            }
+        },
+        "additionalProperties": False
+    }
+
+
+def validate_rasa_nlu_data(data):
+    # type: (dict) -> None
+    """Validate rasa training data format to ensure proper training. Raises exception on failure."""
+    from jsonschema import validate
+    from jsonschema import ValidationError
+
+    try:
+        validate(data, rasa_nlu_data_schema())
+    except ValidationError as e:
+        e.message += \
+            ". Failed to validate training data, make sure your data is valid. " + \
+            "For more information about the format visit " + \
+            "https://rasa-nlu.readthedocs.io/en/latest/dataformat.html"
+        raise e
+
+
 def load_rasa_data(filename):
     # type: (str) -> TrainingData
     """Loads training data stored in the rasa NLU data format."""
 
     with io.open(filename, encoding="utf-8-sig") as f:
         data = json.loads(f.read())
+    validate_rasa_nlu_data(data)
     common = data['rasa_nlu_data'].get("common_examples", list())
     intent = data['rasa_nlu_data'].get("intent_examples", list())
     entity = data['rasa_nlu_data'].get("entity_examples", list())

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pytest==3.0.7
 typing==3.5.3.0
 future==0.16.0
 six==1.10.0
+jsonschema==2.6.0


### PR DESCRIPTION
**Proposed changes**:
- validate rasa nlu formatted training data before using it
- a couple of users used wrongly formatted training data which results in strange errors as we simple read the data as json and use it as an object. previous to this PR, errors would surface in strange places.
- this disallows to use e.g. `3` (as a number) as a `"value"` for an entity (see the changed training example). I don't think that this would result in anything useful anyway (since we will never produce non string entity values).

**Status**:
- [x] ready for code review
- [x] documentation updated
- [x] changelog updated
