### PR TITLE
Update api.py

### DIFF
--- a/rasa_nlu/emulators/api.py
+++ b/rasa_nlu/emulators/api.py
@@ -31,7 +31,7 @@ class ApiEmulator(NoEmulator):
 
         return {
             "id": str(uuid.uuid1()),
-            "timestamp": datetime.now().isoformat("T"),
+            "timestamp": datetime.now().isoformat(),
             "result": {
                 "source": "agent",
                 "resolvedQuery": data["text"],


### PR DESCRIPTION
Fixes issue with api.ai emulator throwing an error when trying to parse the date/time. File "rasa_nlu/emulators/api.py", line 34, in normalise_response_json "timestamp": datetime.now().isoformat("T"), TypeError: isoformat() argument 1 must be char, not unicode

**Proposed changes**:
- ...

**Status**:
- [x] ready for code review
- [x] there are tests for the functionality
- [x] documentation updated
- [x] changelog updated
