### PR TITLE
Automtically enable models in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN bash entrypoint.sh download spacy en
 #Uncomment this line using mitie and sklearn (and comment the lines of the other models)
 #COPY config_mitie_sklearn.json /app/config.json 
 
-
+RUN ls /app
 
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,23 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
   pip install -r "${RASA_NLU_HOME}/requirements.txt"
 
-RUN python setup.py install
+RUN python setup.py install 
 
-RUN ls /app
+
+#Uncomment these lines for using spacy (and comment the lines of the other models)
+COPY config_spacy.json /app/config.json 
+#Uncomment the language you want to use for spacy
+RUN bash entrypoint.sh download spacy en
+#RUN bash entrypoint.sh download spacy de
+
+#Uncomment these lines for using mittie (and comment the lines of the other models)
+#COPY config_mitie.json /app/config.json
+#RUN bash entrypoint.sh download mitie
+
+#Uncomment this line using mitie and sklearn (and comment the lines of the other models)
+#COPY config_mitie_sklearn.json /app/config.json 
+
+
 
 EXPOSE 5000
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,8 +39,36 @@ function download_package {
     esac
 }
 
+# If there is only a model, set it as default model
+function set_default_model {
+   if [ -d "/app/models" ]
+     echo "Models directory exists"
+     then
+     if [ ! -d "/app/models/default" ]
+       then
+       echo "Default model doesn't exist"
+       if [ "x1" == x`ls -ld /app/models/* | wc -l` ]
+          then
+          echo "Renaming existing model to default"
+          mv `ls -d /app/models/*` /app/models/default
+          if [ -d "/app/models/default" ]
+          then
+              echo "Model renamed to default"
+          else
+              echo "Model couldn't be renamed to default"
+          fi
+       else
+          echo "There are no models or more than one"
+       fi
+     fi
+   fi
+}
+
+
+
 case ${1} in
     start)
+        set_default_model
         exec python -m rasa_nlu.server "${@:2}" 
         ;;
     run)


### PR DESCRIPTION
**Proposed changes**:
I added lines (some commented) in Dockerfile for getting running a model just after build the container. Default is spacy using english, but can be changed commenting and uncommenting lines in Dockerfile.

