### PR TITLE
replaced spacy_ner with ner_crf in standard pipeline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,7 @@ Changed
     to ``{"intent": {"name": "greeting", "confidence": 0.9}, "entities": []}``
 - camel cased MITIE classes (e.g. ``MITIETokenizer`` → ``MitieTokenizer``)
 - model metadata changed, see migration guide
-- updated to spacy 1.7 (breaks existing spacy models!)
+- updated to spacy 1.7 and dropped training and loading capabilities for the spacy component (breaks existing spacy models!)
 - introduced compatibility with both Python 2 and 3
 
 Removed

--- a/_pytest/test_config.py
+++ b/_pytest/test_config.py
@@ -2,18 +2,19 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-import tempfile
 import pytest
 import json
 import os
 import io
+import tempfile
 
-import six
 from typing import Text
 
 import rasa_nlu
+from utilities import write_file_config
 from conftest import CONFIG_DEFAULTS_PATH
 from rasa_nlu.config import RasaNLUConfig
+from rasa_nlu.registry import registered_pipeline_templates
 
 
 with io.open(CONFIG_DEFAULTS_PATH, "r") as f:
@@ -31,11 +32,9 @@ def test_blank_config():
     file_config = {}
     cmdline_args = {}
     env_vars = {}
-    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json") as f:
-        f.write(json.dumps(file_config))
-        f.flush()
-        final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
-        assert final_config.as_dict() == defaults
+    f = write_file_config(file_config)
+    final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+    assert final_config.as_dict() == defaults
 
 
 def test_invalid_config_json():
@@ -64,41 +63,52 @@ def test_file_config_unchanged():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {}
     env_vars = {}
-    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json") as f:
-        f.write(json.dumps(file_config))
-        f.flush()
-        final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
-        assert final_config['path'] == "/path/to/dir"
+    f = write_file_config(file_config)
+    final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+    assert final_config['path'] == "/path/to/dir"
 
 
 def test_cmdline_overrides_init():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {"path": "/alternate/path"}
     env_vars = {}
-    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json") as f:
-        f.write(json.dumps(file_config))
-        f.flush()
-        final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
-        assert final_config['path'] == "/alternate/path"
+    f = write_file_config(file_config)
+    final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+    assert final_config['path'] == "/alternate/path"
 
 
 def test_envvar_overrides_init():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {}
     env_vars = {"RASA_PATH": "/alternate/path"}
-    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json") as f:
-        f.write(json.dumps(file_config))
-        f.flush()
-        final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
-        assert final_config['path'] == "/alternate/path"
+    f = write_file_config(file_config)
+    final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+    assert final_config['path'] == "/alternate/path"
 
 
 def test_cmdline_overrides_envvar():
     file_config = {"path": "/path/to/dir"}
     cmdline_args = {"path": "/another/path"}
     env_vars = {"RASA_PATH": "/alternate/path"}
-    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json") as f:
-        f.write(json.dumps(file_config))
-        f.flush()
-        final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
-        assert final_config['path'] == "/another/path"
+    f = write_file_config(file_config)
+    final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+    assert final_config['path'] == "/another/path"
+
+
+def test_pipeline_splits_list():
+    file_config = {}
+    cmdline_args = {"pipeline": "nlp_spacy,ner_spacy"}
+    env_vars = {}
+    f = write_file_config(file_config)
+    final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+    assert final_config['pipeline'] == ["nlp_spacy", "ner_spacy"]
+
+
+def test_pipeline_looksup_registry():
+    pipeline_template = list(registered_pipeline_templates)[0]
+    file_config = {}
+    cmdline_args = {"pipeline": pipeline_template}
+    env_vars = {}
+    f = write_file_config(file_config)
+    final_config = RasaNLUConfig(f.name, env_vars, cmdline_args)
+    assert final_config['pipeline'] == registered_pipeline_templates[pipeline_template]

--- a/_pytest/utilities.py
+++ b/_pytest/utilities.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from builtins import object
 import tempfile
 import pytest
+import json
 
 from rasa_nlu import registry
 from rasa_nlu.config import RasaNLUConfig
@@ -23,6 +24,13 @@ def base_test_conf(pipeline_template):
         "path": tempfile.mkdtemp(),
         "data": "./data/examples/rasa/demo-rasa.json"
     })
+
+
+def write_file_config(file_config):
+    with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json", delete=False) as f:
+        f.write(json.dumps(file_config))
+        f.flush()
+        return f
 
 
 def interpreter_for(component_builder, config):

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -129,14 +129,6 @@ spacy_model_name
     If the spacy model to be used has a name that is different from the language tag (``"en"``, ``"de"``, etc.),
     the model name can be specified using this configuration variable. The name will be passed to ``spacy.load(name)``.
 
-fine_tune_spacy_ner
-~~~~~~~~~~~~~~~~~~~
-
-:Type: ``bool``
-:Examples: ``true``
-:Description:
-    Fine tune existing spacy NER models vs training from scratch. (``ner_spacy`` component only)
-
 server_model_dirs
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -6,7 +6,7 @@ how you can migrate from one version to another.
 0.7.x to master
 ---------------
 
-- Due to the update of spacy to 1.7 (and them breaking backwards compatibility), spacy models need to be retrained.
+- The training and loading capability for the spacy entity extraction was dropped in favor of the new CRF extractor. That means models need to be retrained using the crf extractor.
 
 - The parameter and configuration value name of ``backend`` changed to ``pipeline``.
 

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -16,7 +16,7 @@ the processing has finished. E.g. for the sentence ``"I am looking for Chinese f
     {
         "text": "I am looking for Chinese food",
         "entities": [
-            {"start": 8, "end": 15, "value": "chinese", "entity": "cuisine"}
+            {"start": 8, "end": 15, "value": "chinese", "entity": "cuisine", "extractor": "ner_crf"}
         ],
         "intent": {"confidence": 0.6485910906220309, "name": "restaurant_search"},
         "intent_ranking": [
@@ -26,7 +26,7 @@ the processing has finished. E.g. for the sentence ``"I am looking for Chinese f
     }
 
 is created as a combination of the results of the different components in the pre-configured pipeline ``spacy_sklearn``.
-For example, the ``entities`` attribute is created by the ``ner_spacy`` component.
+For example, the ``entities`` attribute is created by the ``ner_crf`` component.
 
 Pre-configured Pipelines
 ------------------------
@@ -37,7 +37,7 @@ Here is a list of the existing templates:
 +---------------+----------------------------------------------------------------------------------------------------------------------------+
 | template name | corresponding pipeline                                                                                                     |
 +===============+============================================================================================================================+
-| spacy_sklearn | ``["nlp_spacy", "ner_spacy", "ner_synonyms", "intent_featurizer_spacy", "intent_classifier_sklearn"]``                    |
+| spacy_sklearn | ``["nlp_spacy", "ner_crf", "ner_synonyms", "intent_featurizer_spacy", "intent_classifier_sklearn"]``                    |
 +---------------+----------------------------------------------------------------------------------------------------------------------------+
 | mitie         | ``["nlp_mitie", "tokenizer_mitie", "ner_mitie", "ner_synonyms", "intent_classifier_mitie"]``                              |
 +---------------+----------------------------------------------------------------------------------------------------------------------------+
@@ -47,7 +47,7 @@ Here is a list of the existing templates:
 +---------------+----------------------------------------------------------------------------------------------------------------------------+
 
 Creating your own pipelines is possible by directly passing the names of the components to rasa NLU in the ``pipeline``
-configuration variable, e.g. ``"pipeline": ["nlp_spacy", "ner_spacy", "ner_synonyms"]``. This creates a pipeline
+configuration variable, e.g. ``"pipeline": ["nlp_spacy", "ner_crf", "ner_synonyms"]``. This creates a pipeline
 that only does entity recognition, but no intent classification. Hence, the output will not contain any useful intents.
 
 Built-in Components
@@ -231,7 +231,7 @@ ner_spacy
 
 :Description:
     Using spacy this component predicts the entities of a message. spacy uses a statistical BILUO transition model.
-    The entity extractor expects around 5000 training examples per entity to perform good.
+    As of now, this component can only use the spacy builtin entity extraction models and can not be retrained.
 
 ner_synonyms
 ~~~~~~~~~~~~

--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -67,11 +67,11 @@ class RasaNLUConfig(object):
             self.override(file_config)
 
         if env_vars is not None:
-            env_config = self.format_env_vars(env_vars)
+            env_config = self.create_env_config(env_vars)
             self.override(env_config)
 
         if cmdline_args is not None:
-            cmdline_config = {k: v for k, v in list(cmdline_args.items()) if v is not None}
+            cmdline_config = self.create_cmdline_config(cmdline_args)
             self.override(cmdline_config)
 
         if isinstance(self.__dict__['pipeline'], six.string_types):
@@ -111,9 +111,19 @@ class RasaNLUConfig(object):
     def view(self):
         return json.dumps(self.__dict__, indent=4)
 
-    def format_env_vars(self, env_vars):
+    def split_pipeline(self, config):
+        if "pipeline" in config.keys() and "," in config["pipeline"]:
+            config["pipeline"] = config["pipeline"].split(",")
+        return config
+
+    def create_cmdline_config(self, cmdline_args):
+        cmdline_config = {k: v for k, v in list(cmdline_args.items()) if v is not None}
+        return self.split_pipeline(cmdline_config)
+
+    def create_env_config(self, env_vars):
         keys = [key for key in env_vars.keys() if "RASA" in key]
-        return {key.split('RASA_')[1].lower(): env_vars[key] for key in keys}
+        env_config = {key.split('RASA_')[1].lower(): env_vars[key] for key in keys}
+        return self.split_pipeline(env_config)
 
     def is_set(self, key):
         return key in self.__dict__ and self[key] is not None

--- a/rasa_nlu/extractors/spacy_entity_extractor.py
+++ b/rasa_nlu/extractors/spacy_entity_extractor.py
@@ -28,9 +28,9 @@ class SpacyEntityExtractor(EntityExtractor):
         # type: () -> List[Text]
         return ["spacy"]
 
-    def process(self, spacy_doc, spacy_nlp, entities):
+    def process(self, text, spacy_nlp, entities):
         # type: (Doc, Language, List[Dict[Text, Any]]) -> Dict[Text, Any]
-        extracted = self.add_extractor_name(self.extract_entities(spacy_doc, spacy_nlp))
+        extracted = self.add_extractor_name(self.extract_entities(text, spacy_nlp))
         entities.extend(extracted)
         return {
             "entities": entities

--- a/rasa_nlu/registry.py
+++ b/rasa_nlu/registry.py
@@ -50,7 +50,7 @@ registered_components = {
 registered_pipeline_templates = {
     "spacy_sklearn": [
         "nlp_spacy",
-        "ner_spacy",
+        "ner_crf",
         "ner_synonyms",
         "intent_featurizer_spacy",
         "intent_classifier_sklearn",

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -30,6 +30,8 @@ def create_arg_parser():
     parser.add_argument('-m', '--mitie_file',
                         help='file with mitie total_word_feature_extractor')
     parser.add_argument('-p', '--path', help="path where model files will be saved")
+    parser.add_argument('--pipeline', help="The pipeline to use. Either a pipeline template name or a list of " +
+                                           "components separated by comma")
     parser.add_argument('-P', '--port', type=int, help='port on which to run server')
     parser.add_argument('-t', '--token',
                         help="auth token. If set, reject requests which don't provide this token as a query parameter")

--- a/rasa_nlu/version.py
+++ b/rasa_nlu/version.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = '0.8.0a13'
+__version__ = '0.8.0a14'


### PR DESCRIPTION
**Proposed changes**:
- fixes #319 

Hey wasn't to sure about what you mean by removing the training capability of the component:
1. Does this mean to completely remove the training methods: train, finetune, etc.?
2. But then it seems the training is also somehow related to the extraction of entities: 
`if spacy_nlp.entity is not None and self.fine_tune_spacy_ner:`. So I didn't remove anything yet.

@tmbo Could you take over the removal of the necessary parts given the time constraints and your knowledge of the component's internals? Happy to review the changes!

**Status**:
- [x] ready for code review
- [x] there are tests for the functionality
- [x] documentation updated
- [x] changelog updated
