### PR TITLE
Ducking error

### DIFF
--- a/rasa_nlu/extractors/duckling_extractor.py
+++ b/rasa_nlu/extractors/duckling_extractor.py
@@ -101,7 +101,7 @@ class DucklingExtractor(EntityExtractor):
         # type: (Text) -> Dict[Text, Any]
         file_name = self.name+".json"
         full_name = os.path.join(model_dir, file_name)
-            with io.open(full_name, 'w', encoding="utf-8") as f:
+        with io.open(full_name, 'w', encoding="utf-8") as f:
             f.write(json.dumps({"dimensions": self.dimensions}, ensure_ascii=False))
         return {"ner_duckling_persisted": file_name}
 

--- a/rasa_nlu/extractors/duckling_extractor.py
+++ b/rasa_nlu/extractors/duckling_extractor.py
@@ -101,8 +101,8 @@ class DucklingExtractor(EntityExtractor):
         # type: (Text) -> Dict[Text, Any]
         file_name = self.name+".json"
         full_name = os.path.join(model_dir, file_name)
-        with io.open(full_name, 'w', encoding="utf-8") as f:
-            f.write(json.dumps({"dimensions": self.dimensions}, ensure_ascii=False))
+        with io.open(full_name, 'w') as f:
+            f.write(unicode(json.dumps({"dimensions": self.dimensions})))
         return {"ner_duckling_persisted": file_name}
 
     @classmethod

--- a/rasa_nlu/extractors/duckling_extractor.py
+++ b/rasa_nlu/extractors/duckling_extractor.py
@@ -102,7 +102,7 @@ class DucklingExtractor(EntityExtractor):
         file_name = self.name+".json"
         full_name = os.path.join(model_dir, file_name)
         with io.open(full_name, 'w') as f:
-            f.write(unicode(json.dumps({"dimensions": self.dimensions})))
+            f.write(json.dumps({"dimensions": self.dimensions}, ensure_ascii=False))
         return {"ner_duckling_persisted": file_name}
 
     @classmethod

--- a/rasa_nlu/extractors/duckling_extractor.py
+++ b/rasa_nlu/extractors/duckling_extractor.py
@@ -85,6 +85,7 @@ class DucklingExtractor(EntityExtractor):
             for match in relevant_matches:
                 entity = {"start": match["start"],
                           "end": match["end"],
+                          "text": match["text"],
                           "value": match["value"]["value"],
                           "entity": match["dim"]}
 
@@ -100,8 +101,8 @@ class DucklingExtractor(EntityExtractor):
         # type: (Text) -> Dict[Text, Any]
         file_name = self.name+".json"
         full_name = os.path.join(model_dir, file_name)
-        with io.open(full_name, 'w') as f:
-            f.write(json.dumps({"dimensions": self.dimensions}))
+            with io.open(full_name, 'w', encoding="utf-8") as f:
+            f.write(json.dumps({"dimensions": self.dimensions}, ensure_ascii=False))
         return {"ner_duckling_persisted": file_name}
 
     @classmethod


### PR DESCRIPTION
fixes the TypeError: write() argument 1 must be unicode, not str

added entity item ‘text’ to return the text Duckling used to match